### PR TITLE
Improve `Negate` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Negate`'s functions `x`, `y`, `z` no longer take an `invert` parameter and assume it is `true`
-- `Negate::all`'s current function has been moved to `Negate::splat`
-- `Negate::all` no longer takes an `invert` parameter and assumes it is `true` (opposite is `Negate::none`)
-- `Negate::default` is removed - use `Negate::all` instead
+- `Negate`'s functions `x`, `y`, `z` no longer take an `invert` parameter and assume it is `true`.
+- `Negate::all`'s current function has been moved to `Negate::splat`.
+- `Negate::all` no longer takes an `invert` parameter and assumes it is `true` (opposite is `Negate::none`).
+
+### Removed
+
+- `Negate::default` - use `Negate::all` instead.
+
 
 ## [0.4.0] - 2024-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Negate`'s functions `x`, `y`, `z` no longer take an `invert` parameter and assume it is `true`
+- `Negate::all`'s current function has been moved to `Negate::splat`
+- `Negate::all` no longer takes an `invert` parameter and assumes it is `true` (opposite is `Negate::none`)
+- `Negate::default` is removed - use `Negate::all` instead
+
 ## [0.4.0] - 2024-12-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Negate::default` - use `Negate::all` instead.
 
-
 ## [0.4.0] - 2024-12-01
 
 ### Changed

--- a/src/input_context/input_modifier/negate.rs
+++ b/src/input_context/input_modifier/negate.rs
@@ -69,12 +69,6 @@ impl Negate {
     }
 }
 
-impl Default for Negate {
-    fn default() -> Self {
-        Self::splat(true)
-    }
-}
-
 impl InputModifier for Negate {
     fn apply(
         &mut self,
@@ -182,7 +176,7 @@ mod tests {
 
     #[test]
     fn all() {
-        let mut modifier = Negate::default();
+        let mut modifier = Negate::all();
         let actions = ActionsData::default();
         let time = Time::default();
 

--- a/src/input_context/input_modifier/negate.rs
+++ b/src/input_context/input_modifier/negate.rs
@@ -23,7 +23,7 @@ pub struct Negate {
 impl Negate {
     /// Returns [`Self`] with invertion for all axes set to `invert`
     #[must_use]
-    pub fn all(invert: bool) -> Self {
+    pub fn splat(invert: bool) -> Self {
         Self {
             x: invert,
             y: invert,
@@ -31,40 +31,47 @@ impl Negate {
         }
     }
 
-    /// Returns [`Self`] with invertion for x set to `invert`
+    /// Returns [`Self`] with none of the axes inverted.
+    pub fn none() -> Self {
+        Self::splat(false)
+    }
+
+    /// Returns [`Self`] with all of the axes inverted.
+    pub fn all() -> Self {
+        Self::splat(true)
+    }
+
+    /// Returns [`Self`] with the X axis inverted.
     #[must_use]
-    pub fn x(invert: bool) -> Self {
+    pub fn x() -> Self {
         Self {
-            x: invert,
-            y: false,
-            z: false,
+            x: true,
+            ..Self::none()
         }
     }
 
-    /// Returns [`Self`] with invertion for y set to `invert`
+    /// Returns [`Self`] with the Y axis inverted.
     #[must_use]
-    pub fn y(invert: bool) -> Self {
+    pub fn y() -> Self {
         Self {
-            x: false,
-            y: invert,
-            z: false,
+            y: true,
+            ..Self::none()
         }
     }
 
-    /// Returns [`Self`] with invertion for z set to `invert`
+    /// Returns [`Self`] with the Z axis inverted.
     #[must_use]
-    pub fn z(invert: bool) -> Self {
+    pub fn z() -> Self {
         Self {
-            x: false,
-            y: false,
-            z: invert,
+            z: true,
+            ..Self::none()
         }
     }
 }
 
 impl Default for Negate {
     fn default() -> Self {
-        Self::all(true)
+        Self::splat(true)
     }
 }
 
@@ -118,7 +125,7 @@ mod tests {
 
     #[test]
     fn x() {
-        let mut modifier = Negate::x(true);
+        let mut modifier = Negate::x();
         let actions = ActionsData::default();
         let time = Time::default();
 
@@ -137,7 +144,7 @@ mod tests {
 
     #[test]
     fn y() {
-        let mut modifier = Negate::y(true);
+        let mut modifier = Negate::y();
         let actions = ActionsData::default();
         let time = Time::default();
 
@@ -156,7 +163,7 @@ mod tests {
 
     #[test]
     fn z() {
-        let mut modifier = Negate::z(true);
+        let mut modifier = Negate::z();
         let actions = ActionsData::default();
         let time = Time::default();
 

--- a/src/input_context/preset.rs
+++ b/src/input_context/preset.rs
@@ -122,13 +122,13 @@ impl<I: InputBindings> InputBindings for Cardinal<I> {
         let east = self
             .east
             .iter_bindings()
-            .map(|binding| binding.with_modifiers(Negate::default()));
+            .map(|binding| binding.with_modifiers(Negate::all()));
 
         // -Y
         let south = self
             .south
             .iter_bindings()
-            .map(|binding| binding.with_modifiers((Negate::default(), SwizzleAxis::YXZ)));
+            .map(|binding| binding.with_modifiers((Negate::all(), SwizzleAxis::YXZ)));
 
         // X
         let west = self.west.iter_bindings();
@@ -154,7 +154,7 @@ impl<I: InputBindings> InputBindings for Biderectional<I> {
         let negative = self
             .negative
             .iter_bindings()
-            .map(|binding| binding.with_modifiers(Negate::default()));
+            .map(|binding| binding.with_modifiers(Negate::all()));
 
         positive.chain(negative)
     }

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -280,7 +280,7 @@ impl InputContext for DummyContext {
         let block_by = BlockBy::<Blocker>::default();
         let block_events_by = BlockBy::<EventsBlocker>::events_only();
         let swizzle_axis = SwizzleAxis::YXZ;
-        let negate = Negate::default();
+        let negate = Negate::all();
         let scale = Scale::splat(2.0);
 
         ctx.bind::<ChordMember>().to(ChordMember::KEY);


### PR DESCRIPTION
- `Negate::x(false)` -> `Negate::x()` - same for all other axes
- `Negate::all(b)` -> `Negate::splat(b)`
  - `Negate::all` is a shorthand for `splat(true)`
  - `Negate::none` (new) is a shorthand for `splat(false)`
- What do you think of removing `impl Default for Negate`, and making users use `Negate::all` explicitly?