### PR TITLE
Derive `Reflect` for `Input` and `ModKeys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Derive `Reflect` for `Input` and `ModKeys`.
+
 ## [0.7.2] - 2025-01-24
 
 ### Changed

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// If the action's dimension differs from the captured input, it will be converted using
 /// [`ActionValue::convert`](crate::action_value::ActionValue::convert).
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Reflect)]
 pub enum Input {
     /// Keyboard button, will be captured as
     /// [`ActionValue::Bool`](crate::action_value::ActionValue::Bool).
@@ -122,10 +122,12 @@ impl<I: Into<Input>> InputModKeys for I {
     }
 }
 
+/// Keyboard modifiers for both left and right keys.
+#[derive(Default, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Reflect)]
+pub struct ModKeys(u8);
+
 bitflags! {
-    /// Keyboard modifiers for both left and right keys.
-    #[derive(Default, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-    pub struct ModKeys: u8 {
+    impl ModKeys: u8 {
         /// Corresponds to [`KeyCode::AltLeft`] and [`KeyCode::AltRight`].
         const ALT = 0b00000001;
         /// Corresponds to [`KeyCode::ControlLeft`] and [`KeyCode::ControlRight`].


### PR DESCRIPTION
For `ModKeys` it requires macro separation as described in
https://docs.rs/bitflags/latest/bitflags/#custom-derives

Need this change to implement #24. In my game I planning to have dedicated tabs for gamepad and keyboard inputs. But for the example simplicity I want to have a single menu where user can bind any input source.