### PR TITLE
Make systems standalone functions

### DIFF
--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -23,14 +23,12 @@ struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_input_context::<DummyContext>()
-            .add_systems(Startup, Self::spawn);
+            .add_systems(Startup, spawn);
     }
 }
 
-impl GamePlugin {
-    fn spawn(mut commands: Commands) {
-        commands.spawn(DummyContext);
-    }
+fn spawn(mut commands: Commands) {
+    commands.spawn(DummyContext);
 }
 
 #[derive(Component)]

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -26,64 +26,62 @@ impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_input_context::<PlayerBox>()
             .add_input_context::<Swimming>()
-            .add_systems(Startup, Self::spawn)
-            .add_observer(Self::apply_movement)
-            .add_observer(Self::rotate)
-            .add_observer(Self::exit_water)
-            .add_observer(Self::enter_water)
-            .add_observer(Self::start_diving)
-            .add_observer(Self::end_diving);
+            .add_systems(Startup, spawn)
+            .add_observer(apply_movement)
+            .add_observer(rotate)
+            .add_observer(exit_water)
+            .add_observer(enter_water)
+            .add_observer(start_diving)
+            .add_observer(end_diving);
     }
 }
 
-impl GamePlugin {
-    fn spawn(mut commands: Commands) {
-        commands.spawn(Camera2d);
-        commands.spawn(PlayerBox);
-    }
+fn spawn(mut commands: Commands) {
+    commands.spawn(Camera2d);
+    commands.spawn(PlayerBox);
+}
 
-    fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.translation += trigger.value.extend(0.0);
-    }
+fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.translation += trigger.value.extend(0.0);
+}
 
-    fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.rotate_z(FRAC_PI_4);
-    }
+fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.rotate_z(FRAC_PI_4);
+}
 
-    fn enter_water(
-        trigger: Trigger<Started<EnterWater>>,
-        mut commands: Commands,
-        mut players: Query<&mut PlayerColor>,
-    ) {
-        // Change color for visibility.
-        let mut color = players.get_mut(trigger.entity()).unwrap();
-        **color = INDIGO_600.into();
+fn enter_water(
+    trigger: Trigger<Started<EnterWater>>,
+    mut commands: Commands,
+    mut players: Query<&mut PlayerColor>,
+) {
+    // Change color for visibility.
+    let mut color = players.get_mut(trigger.entity()).unwrap();
+    **color = INDIGO_600.into();
 
-        commands.entity(trigger.entity()).insert(Swimming);
-    }
+    commands.entity(trigger.entity()).insert(Swimming);
+}
 
-    fn start_diving(trigger: Trigger<Started<Dive>>, mut players: Query<&mut Visibility>) {
-        let mut visibility = players.get_mut(trigger.entity()).unwrap();
-        *visibility = Visibility::Hidden;
-    }
+fn start_diving(trigger: Trigger<Started<Dive>>, mut players: Query<&mut Visibility>) {
+    let mut visibility = players.get_mut(trigger.entity()).unwrap();
+    *visibility = Visibility::Hidden;
+}
 
-    fn end_diving(trigger: Trigger<Completed<Dive>>, mut players: Query<&mut Visibility>) {
-        let mut visibility = players.get_mut(trigger.entity()).unwrap();
-        *visibility = Visibility::Visible;
-    }
+fn end_diving(trigger: Trigger<Completed<Dive>>, mut players: Query<&mut Visibility>) {
+    let mut visibility = players.get_mut(trigger.entity()).unwrap();
+    *visibility = Visibility::Visible;
+}
 
-    fn exit_water(
-        trigger: Trigger<Started<ExitWater>>,
-        mut commands: Commands,
-        mut players: Query<&mut PlayerColor>,
-    ) {
-        let mut color = players.get_mut(trigger.entity()).unwrap();
-        **color = Default::default();
+fn exit_water(
+    trigger: Trigger<Started<ExitWater>>,
+    mut commands: Commands,
+    mut players: Query<&mut PlayerColor>,
+) {
+    let mut color = players.get_mut(trigger.entity()).unwrap();
+    **color = Default::default();
 
-        commands.entity(trigger.entity()).remove::<Swimming>();
-    }
+    commands.entity(trigger.entity()).remove::<Swimming>();
 }
 
 impl InputContext for PlayerBox {

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -26,58 +26,56 @@ impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_input_context::<OnFoot>()
             .add_input_context::<InCar>()
-            .add_systems(Startup, Self::spawn)
-            .add_observer(Self::apply_movement)
-            .add_observer(Self::rotate)
-            .add_observer(Self::enter_car)
-            .add_observer(Self::exit_car);
+            .add_systems(Startup, spawn)
+            .add_observer(apply_movement)
+            .add_observer(rotate)
+            .add_observer(enter_car)
+            .add_observer(exit_car);
     }
 }
 
-impl GamePlugin {
-    fn spawn(mut commands: Commands) {
-        commands.spawn(Camera2d);
-        commands.spawn((PlayerBox, OnFoot));
-    }
+fn spawn(mut commands: Commands) {
+    commands.spawn(Camera2d);
+    commands.spawn((PlayerBox, OnFoot));
+}
 
-    fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.translation += trigger.value.extend(0.0);
-    }
+fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.translation += trigger.value.extend(0.0);
+}
 
-    fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.rotate_z(FRAC_PI_4);
-    }
+fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.rotate_z(FRAC_PI_4);
+}
 
-    fn enter_car(
-        trigger: Trigger<Started<EnterCar>>,
-        mut commands: Commands,
-        mut players: Query<&mut PlayerColor>,
-    ) {
-        // Change color for visibility.
-        let mut color = players.get_mut(trigger.entity()).unwrap();
-        **color = FUCHSIA_400.into();
+fn enter_car(
+    trigger: Trigger<Started<EnterCar>>,
+    mut commands: Commands,
+    mut players: Query<&mut PlayerColor>,
+) {
+    // Change color for visibility.
+    let mut color = players.get_mut(trigger.entity()).unwrap();
+    **color = FUCHSIA_400.into();
 
-        commands
-            .entity(trigger.entity())
-            .remove::<OnFoot>()
-            .insert(InCar);
-    }
+    commands
+        .entity(trigger.entity())
+        .remove::<OnFoot>()
+        .insert(InCar);
+}
 
-    fn exit_car(
-        trigger: Trigger<Started<ExitCar>>,
-        mut commands: Commands,
-        mut players: Query<&mut PlayerColor>,
-    ) {
-        let mut color = players.get_mut(trigger.entity()).unwrap();
-        **color = Default::default();
+fn exit_car(
+    trigger: Trigger<Started<ExitCar>>,
+    mut commands: Commands,
+    mut players: Query<&mut PlayerColor>,
+) {
+    let mut color = players.get_mut(trigger.entity()).unwrap();
+    **color = Default::default();
 
-        commands
-            .entity(trigger.entity())
-            .remove::<InCar>()
-            .insert(OnFoot);
-    }
+    commands
+        .entity(trigger.entity())
+        .remove::<InCar>()
+        .insert(OnFoot);
 }
 
 #[derive(Component)]

--- a/examples/player_box/mod.rs
+++ b/examples/player_box/mod.rs
@@ -6,24 +6,19 @@ pub(super) struct PlayerBoxPlugin;
 
 impl Plugin for PlayerBoxPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PostUpdate, Self::update_position);
+        app.add_systems(PostUpdate, update_position);
     }
 }
 
-impl PlayerBoxPlugin {
-    fn update_position(
-        mut gizmos: Gizmos,
-        players: Query<(&Visibility, &Transform, &PlayerColor)>,
-    ) {
-        for (visibility, transform, color) in &players {
-            if visibility != Visibility::Hidden {
-                const DEFAULT_SCALE: Vec2 = Vec2::splat(50.0);
-                gizmos.rect(
-                    Isometry3d::new(transform.translation, transform.rotation),
-                    DEFAULT_SCALE + transform.scale.xy(),
-                    color.0,
-                );
-            }
+fn update_position(mut gizmos: Gizmos, players: Query<(&Visibility, &Transform, &PlayerColor)>) {
+    for (visibility, transform, color) in &players {
+        if visibility != Visibility::Hidden {
+            const DEFAULT_SCALE: Vec2 = Vec2::splat(50.0);
+            gizmos.rect(
+                Isometry3d::new(transform.translation, transform.rotation),
+                DEFAULT_SCALE + transform.scale.xy(),
+                color.0,
+            );
         }
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -25,30 +25,28 @@ struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_input_context::<PlayerBox>() // All input contexts should be registered inside the app.
-            .add_systems(Startup, Self::spawn)
-            .add_observer(Self::apply_movement)
-            .add_observer(Self::rotate);
+            .add_systems(Startup, spawn)
+            .add_observer(apply_movement)
+            .add_observer(rotate);
     }
 }
 
-impl GamePlugin {
-    fn spawn(mut commands: Commands) {
-        commands.spawn(Camera2d);
+fn spawn(mut commands: Commands) {
+    commands.spawn(Camera2d);
 
-        // Spawn an entity with a component that implements `InputContext`.
-        commands.spawn(PlayerBox);
-    }
+    // Spawn an entity with a component that implements `InputContext`.
+    commands.spawn(PlayerBox);
+}
 
-    fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        // The value has already been preprocessed by defined modifiers.
-        transform.translation += trigger.value.extend(0.0);
-    }
+fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    // The value has already been preprocessed by defined modifiers.
+    transform.translation += trigger.value.extend(0.0);
+}
 
-    fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.rotate_z(FRAC_PI_4);
-    }
+fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.rotate_z(FRAC_PI_4);
 }
 
 // To define mappings for actions, implement the context trait.

--- a/examples/ui_priority.rs
+++ b/examples/ui_priority.rs
@@ -26,68 +26,66 @@ struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_input_context::<PlayerBox>()
-            .add_systems(Startup, Self::spawn)
-            .add_systems(Update, Self::draw_egui)
-            .add_observer(Self::apply_movement)
-            .add_observer(Self::zoom);
+            .add_systems(Startup, spawn)
+            .add_systems(Update, draw_egui)
+            .add_observer(apply_movement)
+            .add_observer(zoom);
     }
 }
 
-impl GamePlugin {
-    fn spawn(mut commands: Commands) {
-        commands.spawn(Camera2d);
-        commands.spawn(PlayerBox);
+fn spawn(mut commands: Commands) {
+    commands.spawn(Camera2d);
+    commands.spawn(PlayerBox);
 
-        // Setup simple node with text using Bevy UI.
-        commands
-            .spawn(Node {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                align_items: AlignItems::Start,
-                justify_content: JustifyContent::End,
-                ..Default::default()
-            })
-            .with_children(|parent| {
-                parent
-                    .spawn((
-                        Node {
-                            margin: UiRect::all(Val::Px(15.0)),
-                            padding: UiRect::all(Val::Px(15.0)),
+    // Setup simple node with text using Bevy UI.
+    commands
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            align_items: AlignItems::Start,
+            justify_content: JustifyContent::End,
+            ..Default::default()
+        })
+        .with_children(|parent| {
+            parent
+                .spawn((
+                    Node {
+                        margin: UiRect::all(Val::Px(15.0)),
+                        padding: UiRect::all(Val::Px(15.0)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(NEUTRAL_900.into()),
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Interaction::default(), // All UI nodes with `Interaction` component will intercept all mouse input.
+                        Text::new("Bevy UI"),
+                        TextColor(Color::WHITE),
+                        TextFont {
+                            font_size: 30.0,
                             ..Default::default()
                         },
-                        BackgroundColor(NEUTRAL_900.into()),
-                    ))
-                    .with_children(|parent| {
-                        parent.spawn((
-                            Interaction::default(), // All UI nodes with `Interaction` component will intercept all mouse input.
-                            Text::new("Bevy UI"),
-                            TextColor(Color::WHITE),
-                            TextFont {
-                                font_size: 30.0,
-                                ..Default::default()
-                            },
-                        ));
-                    });
-            });
-    }
-
-    fn draw_egui(mut text_edit: Local<String>, mut contexts: EguiContexts) {
-        Window::new("Egui").show(contexts.ctx_mut(), |ui| {
-            ui.label("Type text:");
-            ui.text_edit_singleline(&mut *text_edit);
+                    ));
+                });
         });
-    }
+}
 
-    fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.translation += trigger.value.extend(0.0);
-    }
+fn draw_egui(mut text_edit: Local<String>, mut contexts: EguiContexts) {
+    Window::new("Egui").show(contexts.ctx_mut(), |ui| {
+        ui.label("Type text:");
+        ui.text_edit_singleline(&mut *text_edit);
+    });
+}
 
-    fn zoom(trigger: Trigger<Fired<Zoom>>, mut players: Query<&mut Transform>) {
-        // Scale entity to fake zoom.
-        let mut transform = players.get_mut(trigger.entity()).unwrap();
-        transform.scale += Vec3::splat(trigger.value);
-    }
+fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.translation += trigger.value.extend(0.0);
+}
+
+fn zoom(trigger: Trigger<Fired<Zoom>>, mut players: Query<&mut Transform>) {
+    // Scale entity to fake zoom.
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    transform.scale += Vec3::splat(trigger.value);
 }
 
 impl InputContext for PlayerBox {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,20 +105,18 @@ impl Plugin for EnhancedInputPlugin {
         app.init_resource::<ContextInstances>()
             .init_resource::<ResetInput>()
             .configure_sets(PreUpdate, EnhancedInputSystem.after(InputSystem))
-            .add_systems(PreUpdate, Self::update.in_set(EnhancedInputSystem));
+            .add_systems(PreUpdate, update.in_set(EnhancedInputSystem));
     }
 }
 
-impl EnhancedInputPlugin {
-    fn update(
-        mut commands: Commands,
-        mut reader: InputReader,
-        time: Res<Time<Virtual>>, // We explicitly use `Virtual` to have access to `relative_speed`.
-        mut instances: ResMut<ContextInstances>,
-    ) {
-        reader.update_state();
-        instances.update(&mut commands, &mut reader, &time);
-    }
+fn update(
+    mut commands: Commands,
+    mut reader: InputReader,
+    time: Res<Time<Virtual>>, // We explicitly use `Virtual` to have access to `relative_speed`.
+    mut instances: ResMut<ContextInstances>,
+) {
+    reader.update_state();
+    instances.update(&mut commands, &mut reader, &time);
 }
 
 /// Label for the system that updates input context instances.


### PR DESCRIPTION
I used to put systems under plugin impls to clarify that the system belongs to a plugin.
But looks like in Bevy using standalone systems is more common. I think it's especially makes sense now with observers. Let's follow this pattern.