### PR TITLE
Rename `InputReader` into `ActionsInputState` and move it under `input_context` module

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,3 @@
-pub(super) mod input_reader;
-
 use std::hash::Hash;
 
 use bevy::prelude::*;

--- a/src/input_context.rs
+++ b/src/input_context.rs
@@ -1,3 +1,4 @@
+pub(super) mod actions_input_state;
 pub mod context_instance;
 pub mod events;
 pub mod input_action;
@@ -14,7 +15,7 @@ use std::{
 
 use bevy::prelude::*;
 
-use crate::input::input_reader::{InputReader, ResetInput};
+use actions_input_state::{ActionsInputState, ResetInput};
 use context_instance::ContextInstance;
 
 /// An extension trait for [`App`] to register contexts.
@@ -167,12 +168,12 @@ impl ContextInstances {
     pub(crate) fn update(
         &mut self,
         commands: &mut Commands,
-        reader: &mut InputReader,
+        input_state: &mut ActionsInputState,
         time: &Time<Virtual>,
     ) {
         for group in &mut self.0 {
             for (entity, ctx) in &mut group.instances {
-                ctx.update(commands, reader, time, *entity);
+                ctx.update(commands, input_state, time, *entity);
             }
         }
     }

--- a/src/input_context/actions_input_state.rs
+++ b/src/input_context/actions_input_state.rs
@@ -9,12 +9,16 @@ use bevy::{
 #[cfg(feature = "egui_priority")]
 use bevy_egui::EguiContext;
 
-use super::{GamepadDevice, Input, ModKeys};
-use crate::action_value::ActionValue;
+use crate::{
+    action_value::ActionValue,
+    input::{GamepadDevice, Input, ModKeys},
+};
 
-/// Reads input from multiple sources.
+/// Input state for actions.
+///
+/// Actions can read input values and optionally consume them without affecting Bevy input resources.
 #[derive(SystemParam)]
-pub(crate) struct InputReader<'w, 's> {
+pub(crate) struct ActionsInputState<'w, 's> {
     keys: Res<'w, ButtonInput<KeyCode>>,
     mouse_buttons: Res<'w, ButtonInput<MouseButton>>,
     mouse_motion: Res<'w, AccumulatedMouseMotion>,
@@ -31,7 +35,7 @@ pub(crate) struct InputReader<'w, 's> {
     egui: Query<'w, 's, &'static mut EguiContext>,
 }
 
-impl InputReader<'_, '_> {
+impl ActionsInputState<'_, '_> {
     /// Resets all consumed values and reads mouse events.
     pub(crate) fn update_state(&mut self) {
         self.consumed.reset();
@@ -645,7 +649,7 @@ mod tests {
         );
     }
 
-    fn init_world<'w, 's>() -> (World, SystemState<InputReader<'w, 's>>) {
+    fn init_world<'w, 's>() -> (World, SystemState<ActionsInputState<'w, 's>>) {
         let mut world = World::new();
         world.init_resource::<ButtonInput<KeyCode>>();
         world.init_resource::<ButtonInput<MouseButton>>();
@@ -657,7 +661,7 @@ mod tests {
         world.init_resource::<AccumulatedMouseScroll>();
         world.init_resource::<ResetInput>();
 
-        let state = SystemState::<InputReader>::new(&mut world);
+        let state = SystemState::<ActionsInputState>::new(&mut world);
 
         (world, state)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub mod prelude {
 
 use bevy::{input::InputSystem, prelude::*};
 
-use input::input_reader::{InputReader, ResetInput};
+use input_context::actions_input_state::{ActionsInputState, ResetInput};
 use prelude::*;
 
 /// Initializes contexts and feeds inputs to them.
@@ -112,12 +112,12 @@ impl Plugin for EnhancedInputPlugin {
 impl EnhancedInputPlugin {
     fn update(
         mut commands: Commands,
-        mut reader: InputReader,
+        mut input_state: ActionsInputState,
         time: Res<Time<Virtual>>, // We explicitly use `Virtual` to have access to `relative_speed`.
         mut instances: ResMut<ContextInstances>,
     ) {
-        reader.update_state();
-        instances.update(&mut commands, &mut reader, &time);
+        input_state.update_state();
+        instances.update(&mut commands, &mut input_state, &time);
     }
 }
 


### PR DESCRIPTION
It's not actually a reader and more like a state for actions.
I think this way it will make it more clear.