### PR TITLE
Add `InputEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Derive `Reflect` for `Input` and `ModKeys`.
+- Derive `PartialEq` for `Input`.
 
 ## [0.7.2] - 2025-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ModKeys::pressed` to get currently active modifiers.
+- `EnhancedInputPlugins` that contains all plugins. Use it instead of the `EnhancedInputPlugin`.
+- `InputEventPlugin` that adds `InputEvent`. Can be used to display appropriate button icons or bind any input sources to actions in settings.
+
 ### Changed
 
 - Derive `Reflect` for `Input` and `ModKeys`.
 - Derive `PartialEq` for `Input`.
+- Rename `EnhancedInputPlugin` into `InputContextPlugin`.
+- Replace `EnhancedInputSystem` struct with `EnhancedInputSet` enum.
 
 ## [0.7.2] - 2025-01-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,8 @@ required-features = [
   "bevy/default_font",
 ]
 
+[lints.clippy]
+too_many_arguments = "allow"
+
 [workspace]
 members = ["macros"]

--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -12,7 +12,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(log_plugin),
-            EnhancedInputPlugin,
+            EnhancedInputPlugins,
             GamePlugin,
         ))
         .run();

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            EnhancedInputPlugin,
+            EnhancedInputPlugins,
             PlayerBoxPlugin,
             GamePlugin,
         ))

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            EnhancedInputPlugin,
+            EnhancedInputPlugins,
             PlayerBoxPlugin,
             GamePlugin,
         ))

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -17,7 +17,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            EnhancedInputPlugin,
+            EnhancedInputPlugins,
             PlayerBoxPlugin,
             GamePlugin,
         ))

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            EnhancedInputPlugin,
+            EnhancedInputPlugins,
             PlayerBoxPlugin,
             GamePlugin,
         ))

--- a/examples/ui_priority.rs
+++ b/examples/ui_priority.rs
@@ -14,7 +14,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             EguiPlugin,
-            EnhancedInputPlugin,
+            EnhancedInputPlugins,
             PlayerBoxPlugin,
             GamePlugin,
         ))

--- a/src/action_value.rs
+++ b/src/action_value.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use bevy::prelude::*;
+use bevy::{input::ButtonState, prelude::*};
 use serde::{Deserialize, Serialize};
 
 /// Value for [`Input`](crate::input::Input).
@@ -131,6 +131,12 @@ pub enum ActionValueDim {
     Axis1D,
     Axis2D,
     Axis3D,
+}
+
+impl From<ButtonState> for ActionValue {
+    fn from(value: ButtonState) -> Self {
+        value.is_pressed().into()
+    }
 }
 
 impl From<bool> for ActionValue {

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// If the action's dimension differs from the captured input, it will be converted using
 /// [`ActionValue::convert`](crate::action_value::ActionValue::convert).
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Reflect, PartialEq)]
 pub enum Input {
     /// Keyboard button, will be captured as
     /// [`ActionValue::Bool`](crate::action_value::ActionValue::Bool).

--- a/src/input.rs
+++ b/src/input.rs
@@ -138,6 +138,18 @@ bitflags! {
 }
 
 impl ModKeys {
+    /// Returns an instance with currently active modifiers.
+    pub fn pressed(keys: &ButtonInput<KeyCode>) -> Self {
+        let mut mod_keys = Self::empty();
+        for [key1, key2] in Self::all().iter_keys() {
+            if keys.any_pressed([key1, key2]) {
+                mod_keys |= key1.into();
+            }
+        }
+
+        mod_keys
+    }
+
     /// Returns an iterator over the key codes corresponding to the set modifier bits.
     ///
     /// Each item contains left and right key codes.
@@ -195,5 +207,21 @@ impl GamepadDevice {
 impl From<Entity> for GamepadDevice {
     fn from(value: Entity) -> Self {
         Self::Single(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pressed_mod_keys() {
+        let mut keys = ButtonInput::default();
+        keys.press(KeyCode::ControlLeft);
+        keys.press(KeyCode::ShiftLeft);
+        keys.press(KeyCode::KeyC);
+
+        let mod_keys = ModKeys::pressed(&keys);
+        assert_eq!(mod_keys, ModKeys::CONTROL | ModKeys::SHIFT);
     }
 }

--- a/src/input_event.rs
+++ b/src/input_event.rs
@@ -1,0 +1,109 @@
+use bevy::{
+    input::{
+        gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent},
+        keyboard::KeyboardInput,
+        mouse::{MouseButtonInput, MouseMotion, MouseWheel},
+        InputSystem,
+    },
+    prelude::*,
+};
+
+use super::{prelude::ActionValue, EnhancedInputSet, Input, ModKeys};
+
+/// Adds [`InputEvent`].
+///
+/// Not required for [`InputContextPlugin`](super::input_context::InputContextPlugin) to function.
+pub struct InputEventPlugin;
+
+impl Plugin for InputEventPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<InputEvent>()
+            .configure_sets(PreUpdate, EnhancedInputSet::SendEvents.after(InputSystem))
+            .add_systems(PreUpdate, send_events.in_set(EnhancedInputSet::SendEvents));
+    }
+}
+
+fn send_events(
+    mut input_events: EventWriter<InputEvent>,
+    mut key_events: EventReader<KeyboardInput>,
+    mut mouse_button_events: EventReader<MouseButtonInput>,
+    mut mouse_motion: EventReader<MouseMotion>,
+    mut mouse_wheel: EventReader<MouseWheel>,
+    mut gamepad_button_events: EventReader<GamepadButtonChangedEvent>,
+    mut gamepad_axis_events: EventReader<GamepadAxisChangedEvent>,
+    keys: Res<ButtonInput<KeyCode>>,
+) {
+    let mod_keys = ModKeys::pressed(&keys);
+
+    let keys = key_events.read().map(move |event| InputEvent {
+        entity: event.window,
+        input: Input::Keyboard {
+            key: event.key_code,
+            // Exclude current key from modifiers.
+            mod_keys: mod_keys & !ModKeys::from(event.key_code),
+        },
+        value: event.state.into(),
+    });
+
+    let mouse_buttons = mouse_button_events.read().map(move |event| InputEvent {
+        entity: event.window,
+        input: Input::MouseButton {
+            button: event.button,
+            mod_keys,
+        },
+        value: event.state.into(),
+    });
+
+    let mouse_motion = mouse_motion.read().map(move |event| InputEvent {
+        entity: Entity::PLACEHOLDER,
+        input: Input::MouseMotion { mod_keys },
+        value: event.delta.into(),
+    });
+
+    let mouse_wheel = mouse_wheel.read().map(move |event| InputEvent {
+        entity: event.window,
+        input: Input::MouseWheel { mod_keys },
+        value: (event.x, event.y).into(),
+    });
+
+    let gamepad_buttons = gamepad_button_events.read().map(move |event| InputEvent {
+        entity: event.entity,
+        input: event.button.into(),
+        value: event.state.into(),
+    });
+
+    let gamepad_axes = gamepad_axis_events.read().map(|event| InputEvent {
+        entity: event.entity,
+        input: event.axis.into(),
+        value: event.value.into(),
+    });
+
+    input_events.send_batch(
+        keys.chain(mouse_buttons)
+            .chain(mouse_motion)
+            .chain(mouse_wheel)
+            .chain(gamepad_buttons)
+            .chain(gamepad_axes),
+    );
+}
+
+/// An event that wraps events from `bevy_input` into a single event type.
+///
+/// This can be used to display appropriate button icons or bind any input sources to actions in settings.
+///
+/// Modifier key presses will be emitted both as separate events and included as [`ModKeys`] for other keys.
+#[derive(Event, Clone, Copy, Debug, PartialEq)]
+pub struct InputEvent {
+    /// The entity related to the input.
+    ///
+    /// - For keyboard and mouse inputs, this is the window entity.
+    /// - For gamepad inputs, this is the gamepad entity.
+    /// - For mouse wheel inputs, this is [`Entity::PLACEHOLDER`] since winit doesn't provide this information.
+    pub entity: Entity,
+
+    /// The input that changed.
+    pub input: Input,
+
+    /// The new value of the input.
+    pub value: ActionValue,
+}

--- a/tests/accumulation.rs
+++ b/tests/accumulation.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn max_abs() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -25,7 +25,7 @@ fn max_abs() {
 #[test]
 fn cumulative() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -6,7 +6,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn explicit() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -47,7 +47,7 @@ fn explicit() {
 #[test]
 fn implicit() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -120,7 +120,7 @@ fn implicit() {
 #[test]
 fn blocker() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -193,7 +193,7 @@ fn blocker() {
 #[test]
 fn events_blocker() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();

--- a/tests/consume_input.rs
+++ b/tests/consume_input.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn consume() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<ConsumeOnly>();
 
     let entity1 = app.world_mut().spawn(ConsumeOnly).id();
@@ -34,7 +34,7 @@ fn consume() {
 #[test]
 fn passthrough() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<PassthroughOnly>();
 
     let entity1 = app.world_mut().spawn(PassthroughOnly).id();
@@ -67,7 +67,7 @@ fn passthrough() {
 #[test]
 fn consume_then_passthrough() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<ConsumeThenPassthrough>();
 
     let entity = app.world_mut().spawn(ConsumeThenPassthrough).id();
@@ -93,7 +93,7 @@ fn consume_then_passthrough() {
 #[test]
 fn passthrough_then_consume() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<PassthroughThenConsume>();
 
     let entity = app.world_mut().spawn(PassthroughThenConsume).id();

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn any() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<AnyGamepad>();
 
     let gamepad_entity1 = app.world_mut().spawn(Gamepad::default()).id();
@@ -39,7 +39,7 @@ fn any() {
 #[test]
 fn by_id() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<SingleGamepad>();
 
     let gamepad_entity1 = app.world_mut().spawn(Gamepad::default()).id();

--- a/tests/context_instance.rs
+++ b/tests/context_instance.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn removal() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -27,7 +27,7 @@ fn removal() {
 #[test]
 fn rebuild() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();

--- a/tests/dim.rs
+++ b/tests/dim.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn bool() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -35,7 +35,7 @@ fn bool() {
 #[test]
 fn axis1d() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -66,7 +66,7 @@ fn axis1d() {
 #[test]
 fn axis2d() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -97,7 +97,7 @@ fn axis2d() {
 #[test]
 fn axis3d() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();

--- a/tests/input_event.rs
+++ b/tests/input_event.rs
@@ -1,0 +1,198 @@
+use bevy::{
+    input::{
+        gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent},
+        keyboard::{Key, KeyboardInput},
+        mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
+        ButtonState, InputPlugin,
+    },
+    prelude::*,
+};
+use bevy_enhanced_input::prelude::*;
+
+#[test]
+fn keyboard() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins));
+
+    app.world_mut().send_event(KeyboardInput {
+        key_code: KeyCode::ControlLeft,
+        logical_key: Key::Control,
+        state: ButtonState::Pressed,
+        repeat: false,
+        window: Entity::PLACEHOLDER,
+    });
+    app.world_mut().send_event(KeyboardInput {
+        key_code: KeyCode::KeyA,
+        logical_key: Key::Dead(None),
+        state: ButtonState::Pressed,
+        repeat: false,
+        window: Entity::PLACEHOLDER,
+    });
+
+    app.update();
+
+    let events: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Events<InputEvent>>()
+        .drain()
+        .collect();
+    assert_eq!(
+        events,
+        [
+            InputEvent {
+                entity: Entity::PLACEHOLDER,
+                input: Input::Keyboard {
+                    key: KeyCode::ControlLeft,
+                    mod_keys: Default::default()
+                },
+                value: true.into()
+            },
+            InputEvent {
+                entity: Entity::PLACEHOLDER,
+                input: Input::Keyboard {
+                    key: KeyCode::KeyA,
+                    mod_keys: ModKeys::CONTROL
+                },
+                value: true.into()
+            }
+        ]
+    );
+}
+
+#[test]
+fn mouse_button() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins));
+
+    app.world_mut().send_event(MouseButtonInput {
+        button: MouseButton::Left,
+        state: ButtonState::Pressed,
+        window: Entity::PLACEHOLDER,
+    });
+
+    app.update();
+
+    let events: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Events<InputEvent>>()
+        .drain()
+        .collect();
+    assert_eq!(
+        events,
+        [InputEvent {
+            entity: Entity::PLACEHOLDER,
+            input: MouseButton::Left.into(),
+            value: true.into()
+        }]
+    );
+}
+
+#[test]
+fn mouse_motion() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins));
+
+    app.world_mut().send_event(MouseMotion { delta: Vec2::ONE });
+
+    app.update();
+
+    let events: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Events<InputEvent>>()
+        .drain()
+        .collect();
+    assert_eq!(
+        events,
+        [InputEvent {
+            entity: Entity::PLACEHOLDER,
+            input: Input::mouse_motion(),
+            value: Vec2::ONE.into()
+        }]
+    );
+}
+
+#[test]
+fn mouse_wheel() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins));
+
+    app.world_mut().send_event(MouseWheel {
+        unit: MouseScrollUnit::Pixel,
+        x: 2.0,
+        y: 2.0,
+        window: Entity::PLACEHOLDER,
+    });
+
+    app.update();
+
+    let events: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Events<InputEvent>>()
+        .drain()
+        .collect();
+    assert_eq!(
+        events,
+        [InputEvent {
+            entity: Entity::PLACEHOLDER,
+            input: Input::mouse_wheel(),
+            value: Vec2::new(2.0, 2.0).into()
+        }]
+    );
+}
+
+#[test]
+fn gamepad_button() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins));
+
+    app.world_mut().send_event(GamepadButtonChangedEvent {
+        entity: Entity::PLACEHOLDER,
+        button: GamepadButton::North,
+        state: ButtonState::Pressed,
+        value: 1.0,
+    });
+
+    app.update();
+
+    let events: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Events<InputEvent>>()
+        .drain()
+        .collect();
+    assert_eq!(
+        events,
+        [InputEvent {
+            entity: Entity::PLACEHOLDER,
+            input: Input::GamepadButton(GamepadButton::North),
+            value: true.into()
+        }]
+    );
+}
+
+#[test]
+fn gamepad_axis() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins));
+
+    app.world_mut().send_event(GamepadAxisChangedEvent {
+        entity: Entity::PLACEHOLDER,
+        axis: GamepadAxis::LeftStickX,
+        value: 1.0,
+    });
+
+    app.update();
+
+    let events: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Events<InputEvent>>()
+        .drain()
+        .collect();
+    assert_eq!(
+        events,
+        [InputEvent {
+            entity: Entity::PLACEHOLDER,
+            input: Input::GamepadAxis(GamepadAxis::LeftStickX),
+            value: 1.0.into()
+        }]
+    );
+}

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn keys() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -48,7 +48,7 @@ fn keys() {
 #[test]
 fn dpad() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let gamepad_entity = app.world_mut().spawn(Gamepad::default()).id();
@@ -85,7 +85,7 @@ fn dpad() {
 #[test]
 fn sticks() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let gamepad_entity = app.world_mut().spawn(Gamepad::default()).id();

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn prioritization() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<First>()
         .add_input_context::<Second>();
 

--- a/tests/require_reset.rs
+++ b/tests/require_reset.rs
@@ -4,7 +4,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn layering() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<First>()
         .add_input_context::<Second>();
 
@@ -58,7 +58,7 @@ fn layering() {
 #[test]
 fn switching() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<First>()
         .add_input_context::<Second>();
 

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -6,7 +6,7 @@ use bevy_enhanced_input::prelude::*;
 #[test]
 fn input_level() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -94,7 +94,7 @@ fn input_level() {
 #[test]
 fn action_level() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();
@@ -182,7 +182,7 @@ fn action_level() {
 #[test]
 fn both_levels() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugins))
         .add_input_context::<DummyContext>();
 
     let entity = app.world_mut().spawn(DummyContext).id();


### PR DESCRIPTION
Can be used to display appropriate button icons or bind any input sources to actions in settings. In my game I only bind keyboard inputs (and planning to bind gamepad inputs in a separate settings tab), but for the example I want to showcase any `Input` serialization.
Emitted by separate `InputEventPlugin`.

To organize it nicely, I moved current `EnhancedInputPlugin` under `input_context` module and renamed it into `InputContextPlugin` since it's responsible only for updating contexts.
And added `EnhancedInputPlugins` (plural) group that contains both `InputEventPlugin` and `InputContextPlugin`.

Both plugins are optional and can function without each other.