### PR TITLE
Prepare for Possible `no_std` Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ required-features = [
 
 [lints.clippy]
 type_complexity = "allow"
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
 
 [workspace]
 members = ["macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["/src", "/tests", "/examples", "/LICENSE*"]
 bevy_enhanced_input_macros = { path = "macros", version = "0.7.0" }
 bevy = { version = "0.15", default-features = false, features = ["serialize"] }
 bevy_egui = { version = "0.33", default-features = false, optional = true }
-serde = "1.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.6", features = ["serde"] }
 
 [dev-dependencies]

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -2,7 +2,7 @@
 
 mod player_box;
 
-use std::f32::consts::FRAC_PI_4;
+use core::f32::consts::FRAC_PI_4;
 
 use bevy::{color::palettes::tailwind::INDIGO_600, prelude::*};
 use bevy_enhanced_input::prelude::*;

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -2,7 +2,7 @@
 
 mod player_box;
 
-use std::f32::consts::FRAC_PI_4;
+use core::f32::consts::FRAC_PI_4;
 
 use bevy::{color::palettes::tailwind::FUCHSIA_400, prelude::*};
 use bevy_enhanced_input::prelude::*;

--- a/examples/keybinding_menu.rs
+++ b/examples/keybinding_menu.rs
@@ -1,4 +1,5 @@
-use std::{error::Error, fmt::Write, fs};
+use core::{error::Error, fmt::Write};
+use std::fs;
 
 use bevy::{
     input::{common_conditions::*, keyboard::KeyboardInput, mouse::MouseButtonInput, ButtonState},

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -2,7 +2,7 @@
 
 mod player_box;
 
-use std::f32::consts::FRAC_PI_4;
+use core::f32::consts::FRAC_PI_4;
 
 use bevy::{
     color::palettes::tailwind::{BLUE_600, RED_600},

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 mod player_box;
 
-use std::f32::consts::FRAC_PI_4;
+use core::f32::consts::FRAC_PI_4;
 
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;

--- a/src/action_value.rs
+++ b/src/action_value.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use bevy::prelude::*;
 use bitflags::bitflags;

--- a/src/input.rs
+++ b/src/input.rs
@@ -265,6 +265,8 @@ impl From<Entity> for GamepadDevice {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     fmt::{self, Display, Formatter},
     hash::Hash,
 };

--- a/src/input_action.rs
+++ b/src/input_action.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use bevy::prelude::*;
 

--- a/src/input_bind.rs
+++ b/src/input_bind.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use core::iter;
 
 use super::{
     input_condition::{InputCondition, InputConditionSet},
@@ -228,7 +228,7 @@ macro_rules! impl_tuple_binds {
             #[allow(non_snake_case)]
             fn bindings(self) -> impl Iterator<Item = InputBind> {
                 let ($($name,)+) = self;
-                std::iter::empty()
+                core::iter::empty()
                     $(.chain($name.bindings()))+
             }
         }

--- a/src/input_bind.rs
+++ b/src/input_bind.rs
@@ -1,3 +1,4 @@
+use alloc::{boxed::Box, vec::Vec};
 use core::iter;
 
 use super::{

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -9,7 +9,7 @@ pub mod pulse;
 pub mod release;
 pub mod tap;
 
-use std::{fmt::Debug, iter};
+use core::{fmt::Debug, iter};
 
 use bevy::prelude::*;
 
@@ -97,7 +97,7 @@ macro_rules! impl_tuple_condition {
             #[allow(non_snake_case)]
             fn conditions(self) -> impl Iterator<Item = Box<dyn InputCondition>> {
                 let ($($name,)+) = self;
-                std::iter::empty()
+                core::iter::empty()
                     $(.chain(iter::once(Box::new($name) as Box<dyn InputCondition>)))+
             }
         }

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -9,6 +9,7 @@ pub mod pulse;
 pub mod release;
 pub mod tap;
 
+use alloc::boxed::Box;
 use core::{fmt::Debug, iter};
 
 use bevy::prelude::*;

--- a/src/input_condition/block_by.rs
+++ b/src/input_condition/block_by.rs
@@ -1,4 +1,4 @@
-use std::{any, marker::PhantomData};
+use core::{any, marker::PhantomData};
 
 use bevy::prelude::*;
 

--- a/src/input_condition/chord.rs
+++ b/src/input_condition/chord.rs
@@ -1,4 +1,4 @@
-use std::{any, marker::PhantomData};
+use core::{any, marker::PhantomData};
 
 use bevy::prelude::*;
 

--- a/src/input_condition/condition_timer.rs
+++ b/src/input_condition/condition_timer.rs
@@ -35,7 +35,7 @@ impl ConditionTimer {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
 

--- a/src/input_condition/hold.rs
+++ b/src/input_condition/hold.rs
@@ -92,7 +92,7 @@ impl InputCondition for Hold {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
     use crate::input_context::ActionsData;

--- a/src/input_condition/hold_and_release.rs
+++ b/src/input_condition/hold_and_release.rs
@@ -74,7 +74,7 @@ impl InputCondition for HoldAndRelease {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
     use crate::input_context::ActionsData;

--- a/src/input_condition/pulse.rs
+++ b/src/input_condition/pulse.rs
@@ -109,7 +109,7 @@ impl InputCondition for Pulse {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
     use crate::input_context::ActionsData;

--- a/src/input_condition/tap.rs
+++ b/src/input_condition/tap.rs
@@ -79,7 +79,7 @@ impl InputCondition for Tap {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
 

--- a/src/input_context.rs
+++ b/src/input_context.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     any::{self, TypeId},
     cmp::Ordering,
     fmt::Debug,

--- a/src/input_context.rs
+++ b/src/input_context.rs
@@ -1,3 +1,4 @@
+use alloc::{boxed::Box, vec::Vec};
 use core::{
     any::{self, TypeId},
     cmp::Ordering,

--- a/src/input_modifier.rs
+++ b/src/input_modifier.rs
@@ -7,6 +7,7 @@ pub mod scale;
 pub mod smooth_nudge;
 pub mod swizzle_axis;
 
+use alloc::boxed::Box;
 use core::{fmt::Debug, iter};
 
 use bevy::prelude::*;

--- a/src/input_modifier.rs
+++ b/src/input_modifier.rs
@@ -7,7 +7,7 @@ pub mod scale;
 pub mod smooth_nudge;
 pub mod swizzle_axis;
 
-use std::{fmt::Debug, iter};
+use core::{fmt::Debug, iter};
 
 use bevy::prelude::*;
 
@@ -56,7 +56,7 @@ macro_rules! impl_tuple_modifiers {
             #[allow(non_snake_case)]
             fn modifiers(self) -> impl Iterator<Item = Box<dyn InputModifier>> {
                 let ($($name,)+) = self;
-                std::iter::empty()
+                core::iter::empty()
                     $(.chain(iter::once(Box::new($name) as Box<dyn InputModifier>)))+
             }
         }

--- a/src/input_modifier/accumulate_by.rs
+++ b/src/input_modifier/accumulate_by.rs
@@ -1,4 +1,4 @@
-use std::{any, marker::PhantomData};
+use core::{any, marker::PhantomData};
 
 use bevy::prelude::*;
 

--- a/src/input_modifier/delta_scale.rs
+++ b/src/input_modifier/delta_scale.rs
@@ -30,7 +30,7 @@ impl InputModifier for DeltaScale {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
 

--- a/src/input_modifier/smooth_nudge.rs
+++ b/src/input_modifier/smooth_nudge.rs
@@ -62,7 +62,7 @@ impl InputModifier for SmoothNudge {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use core::time::Duration;
 
     use super::*;
 

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::hash::Hash;
 
 use bevy::{

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -1,4 +1,4 @@
-use std::hash::Hash;
+use core::hash::Hash;
 
 use bevy::{
     ecs::system::SystemParam,
@@ -41,7 +41,7 @@ impl InputReader<'_, '_> {
         self.consumed.reset();
 
         // Temporary take the original value to avoid issues with the borrow checker.
-        let mut reset_input = std::mem::take(&mut *self.reset_input);
+        let mut reset_input = core::mem::take(&mut *self.reset_input);
         reset_input.retain(|&input| {
             if self.value(input).as_bool() {
                 self.consume(input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ The exact method depends on the OS shell.
 Alternatively you can configure [`LogPlugin`](bevy::log::LogPlugin) to make it permanent.
 */
 
+extern crate alloc;
+
 // Required for the derive macro to work within the crate.
 extern crate self as bevy_enhanced_input;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,10 @@ The exact method depends on the OS shell.
 Alternatively you can configure [`LogPlugin`](bevy::log::LogPlugin) to make it permanent.
 */
 
+#![no_std]
+
+extern crate std;
+
 extern crate alloc;
 
 // Required for the derive macro to work within the crate.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::{
     any::{self, TypeId},
     cmp::Reverse,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     any::{self, TypeId},
     cmp::Reverse,
     marker::PhantomData,

--- a/src/trigger_tracker.rs
+++ b/src/trigger_tracker.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use bevy::prelude::*;
 
 use crate::{

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -1,4 +1,4 @@
-use std::any;
+use core::any;
 
 use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -1,4 +1,4 @@
-use std::any;
+use core::any;
 
 use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;


### PR DESCRIPTION
# Objective

With Bevy 0.16, there is the possibility of many crates gaining `no_std` support. Further, `no_std` support is desirable for crates that will be upstreamed.

## Solution

- Added lints to reduce reliance on `std`.
- Switched to `core::prelude` instead of `std::prelude` using `#![no_std]`.
- Added `std` and `alloc` as external crates.
- Disabled default features on `serde` and re-enabled features used directly by this crate.

---

## Notes

Once Bevy 0.16 releases, `no_std` support should be as simple as:
- Adding an `std` feature and including it in `default`
- Gating the `extern crate std;` statement
- Gating the `ui_priority` and `egui_priority` features on `std`
- Potentially adding other support features such as `libm`, `critical-section`, and `web` for ease of use.