### PR TITLE
Capture gamepad axes as `Axis1D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rename `ContextInstance` into `InputContext`. `InputContext` is no longer a trait. Bindings now configured via observer on `Bindings<C>` (see docs on `InputContextAppExt::add_input_context` for details). Priority now set at runtime via `InputContext::set_priority`. 
 - Move all child modules from `input_context` under crate root (one level upper). 
+- Capture gamepad buttons as `Axis1D` because triggers are also buttons and sometimes have analog value.
 - Rename `input_context` module into `registry` and `context_instance` into `input_context`.
 - Rename `ContextAppExt` into `InputContextAppExt`.
 - Rename `ContextInstances` into `InputContextRegistry`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -32,7 +32,7 @@ pub enum Input {
     /// [`ActionValue::Axis1D`](crate::action_value::ActionValue::Axis1D).
     MouseWheel { mod_keys: ModKeys },
     /// Gamepad button, will be captured as
-    /// [`ActionValue::Bool`](crate::action_value::ActionValue::Bool).
+    /// [`ActionValue::Axis1D`](crate::action_value::ActionValue::Axis1D).
     GamepadButton(GamepadButton),
     /// Gamepad stick axis, will be captured as
     /// [`ActionValue::Axis1D`](crate::action_value::ActionValue::Axis1D).

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -16,7 +16,7 @@ fn any() {
     app.update();
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.digital_mut().press(DummyAction::BUTTON);
+    gamepad1.analog_mut().set(DummyAction::BUTTON, 1.0);
 
     app.update();
 
@@ -25,10 +25,10 @@ fn any() {
     assert_eq!(ctx.action::<DummyAction>().state(), ActionState::Fired);
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.digital_mut().release(DummyAction::BUTTON);
+    gamepad1.analog_mut().set(DummyAction::BUTTON, 0.0);
 
     let mut gamepad2 = app.world_mut().get_mut::<Gamepad>(gamepad_entity2).unwrap();
-    gamepad2.digital_mut().press(DummyAction::BUTTON);
+    gamepad2.analog_mut().set(DummyAction::BUTTON, 1.0);
 
     app.update();
 
@@ -52,7 +52,7 @@ fn by_id() {
     app.update();
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.digital_mut().press(DummyAction::BUTTON);
+    gamepad1.analog_mut().set(DummyAction::BUTTON, 1.0);
 
     app.update();
 
@@ -61,10 +61,10 @@ fn by_id() {
     assert_eq!(ctx.action::<DummyAction>().state(), ActionState::Fired);
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.digital_mut().release(DummyAction::BUTTON);
+    gamepad1.analog_mut().set(DummyAction::BUTTON, 0.0);
 
     let mut gamepad2 = app.world_mut().get_mut::<Gamepad>(gamepad_entity2).unwrap();
-    gamepad2.digital_mut().press(DummyAction::BUTTON);
+    gamepad2.analog_mut().set(DummyAction::BUTTON, 1.0);
 
     app.update();
 

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -65,7 +65,7 @@ fn dpad() {
         (GamepadButton::DPadRight, RIGHT),
     ] {
         let mut gamepad = app.world_mut().get_mut::<Gamepad>(gamepad_entity).unwrap();
-        gamepad.digital_mut().press(button);
+        gamepad.analog_mut().set(button, 1.0);
 
         app.update();
 
@@ -78,7 +78,7 @@ fn dpad() {
         );
 
         let mut gamepad = app.world_mut().get_mut::<Gamepad>(gamepad_entity).unwrap();
-        gamepad.digital_mut().release(button);
+        gamepad.analog_mut().set(button, 0.0);
 
         app.update();
     }


### PR DESCRIPTION
Because triggers are also buttons and sometimes have analog value.