### PR TITLE
Rename `ActionsMarker` into `InputContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rename `InputContext` into `Actions<M>` with its module. Now it's a component. Since a single entity could have multiple actions, the struct now have associated marker `M`. This marker needs to implement `ActionsMarker` trait. We provide a derive macro for it.
+- Rename `InputContext` into `Actions<C>` with its module. Now it's a component. Since a single entity could have multiple actions, the struct now have associated marker `C`. This marker needs to implement the newly added `InputContext` trait. We provide a derive macro for it.
+- Rather than auto-inserting `Actions` when specified input context component is added, users now insert `Actions` directly. The type passed into `InputContextAppExt::add_input_context` is now just a marker for `Actions`, not necessarily a component.
+- Previously users needed to insert component that was registered as input context. Now context is just a regular struct and users need to insert `Actions<C>` directly.
 - Input contexts no longer associated with a component. Users need to manually insert `Actions`.
-- Replace `InputContextAppExt::add_input_context` with `ActionsMarkerAppExt::add_actions_marker` that accepts markers instead of components.
 - `Binding` trigger no longer stores bindings. Just get `Actions` using `Query` and mutate it directly.
 - Rename `ActionBind` into `ActionBinding` and move into `action_binding` module.
 - Rename `ActionBinding::bindings` into `ActionBindings::inputs`.

--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -22,7 +22,7 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_actions_marker::<Dummy>()
+        app.add_input_context::<Dummy>()
             .add_observer(binding)
             .add_systems(Startup, spawn);
     }
@@ -81,7 +81,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
         .with_conditions(BlockBy::<BlockerAction>::default());
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Dummy;
 
 #[derive(Debug, InputAction)]

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -24,8 +24,8 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_actions_marker::<Player>()
-            .add_actions_marker::<Swimming>()
+        app.add_input_context::<Player>()
+            .add_input_context::<Swimming>()
             .add_observer(regular_binding)
             .add_observer(swimming_binding)
             .add_observer(apply_movement)
@@ -113,7 +113,7 @@ fn exit_water(
         .remove::<Actions<Swimming>>();
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Player;
 
 #[derive(Debug, InputAction)]
@@ -130,8 +130,8 @@ struct Rotate;
 struct EnterWater;
 
 /// Overrides some actions from [`Player`].
-#[derive(ActionsMarker)]
-#[actions_marker(priority = 1)]
+#[derive(InputContext)]
+#[input_context(priority = 1)]
 struct Swimming;
 
 #[derive(Debug, InputAction)]

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -24,8 +24,8 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_actions_marker::<OnFoot>()
-            .add_actions_marker::<InCar>()
+        app.add_input_context::<OnFoot>()
+            .add_input_context::<InCar>()
             .add_observer(foot_binding)
             .add_observer(car_binding)
             .add_observer(apply_movement)
@@ -107,7 +107,7 @@ fn exit_car(
         .insert(Actions::<OnFoot>::default());
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct OnFoot;
 
 #[derive(Debug, InputAction)]
@@ -126,7 +126,7 @@ struct Rotate;
 #[input_action(output = bool, require_reset = true)]
 struct EnterCar;
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct InCar;
 
 /// Switches context to [`OnFoot`].

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -28,7 +28,7 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_actions_marker::<Player>()
+        app.add_input_context::<Player>()
             .add_observer(binding)
             .add_observer(apply_movement)
             .add_observer(rotate)
@@ -131,7 +131,7 @@ fn update_gamepads(
 }
 
 /// Used as both input context and component.
-#[derive(ActionsMarker, Component, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(InputContext, Component, Clone, Copy, PartialEq, Eq, Hash)]
 enum Player {
     First,
     Second,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -24,7 +24,7 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_actions_marker::<Player>() // All contexts should be registered.
+        app.add_input_context::<Player>() // All contexts should be registered.
             .add_observer(binding) // Add observer to setup bindings.
             .add_observer(apply_movement)
             .add_observer(rotate)
@@ -35,7 +35,7 @@ impl Plugin for GamePlugin {
 fn spawn(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    // Spawn an entity with a component that implements `ActionsMarker`.
+    // Spawn an entity with a component that implements `InputContext`.
     commands.spawn((PlayerBox, Actions::<Player>::default()));
 }
 
@@ -77,8 +77,8 @@ fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>)
 }
 
 // Since it's possible to have multiple input contexts, you need
-// to define a marker and derive `ActionsMarker` trait.
-#[derive(ActionsMarker)]
+// to define a marker and derive `InputContext` trait.
+#[derive(InputContext)]
 struct Player;
 
 // All actions should implement the `InputAction` trait.

--- a/examples/ui_priority.rs
+++ b/examples/ui_priority.rs
@@ -25,7 +25,7 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_actions_marker::<Player>()
+        app.add_input_context::<Player>()
             .add_observer(binding)
             .add_observer(apply_movement)
             .add_observer(zoom)
@@ -105,7 +105,7 @@ fn zoom(trigger: Trigger<Fired<Zoom>>, mut players: Query<&mut Transform>) {
     transform.scale += Vec3::splat(trigger.value);
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Player;
 
 #[derive(Debug, InputAction)]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -75,12 +75,12 @@ pub fn input_action_derive(item: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(ActionsMarker, attributes(actions_marker))]
+#[proc_macro_derive(InputContext, attributes(input_context))]
 pub fn input_context_derive(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
 
     #[expect(non_snake_case, reason = "item shortcuts")]
-    let ActionsMarker = quote! { ::bevy_enhanced_input::prelude::ActionsMarker };
+    let InputContext = quote! { ::bevy_enhanced_input::prelude::InputContext };
 
     let opts = match InputContextOpts::from_derive_input(&input) {
         Ok(value) => value,
@@ -101,7 +101,7 @@ pub fn input_context_derive(item: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #ActionsMarker for #struct_name #type_generics #where_clause {
+        impl #impl_generics #InputContext for #struct_name #type_generics #where_clause {
             #priority
         }
     })

--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -78,7 +78,7 @@ impl ActionBinding {
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_modifiers(Scale::splat(2.0));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
@@ -94,7 +94,7 @@ impl ActionBinding {
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_modifiers((Scale::splat(2.0), Negate::all()));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
@@ -125,7 +125,7 @@ impl ActionBinding {
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_conditions(Release::default());
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -141,7 +141,7 @@ impl ActionBinding {
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_conditions((Release::default(), JustPress::default()));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -179,7 +179,7 @@ impl ActionBinding {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>()
     ///     .to((KeyCode::Space, GamepadButton::South));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -193,7 +193,7 @@ impl ActionBinding {
     /// # use bevy_enhanced_input::prelude::*;
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>().to(KeyCode::Space.with_mod_keys(ModKeys::CONTROL));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -208,7 +208,7 @@ impl ActionBinding {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>().to(KeyCode::Space.with_conditions(Release::default()));
     /// actions.bind::<Attack>().to(MouseButton::Left.with_modifiers(Scale::splat(10.0)));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -226,7 +226,7 @@ impl ActionBinding {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Zoom>().to(Input::mouse_wheel());
     /// actions.bind::<Move>().to(Input::mouse_motion());
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -244,7 +244,7 @@ impl ActionBinding {
     /// # use bevy_enhanced_input::prelude::*;
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Move>().to(Cardinal::wasd_keys());
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = Vec2)]
@@ -264,7 +264,7 @@ impl ActionBinding {
     /// struct KeyboardSettings {
     ///     inspect: Vec<KeyCode>,
     /// }
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = Vec2)]

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -15,7 +15,7 @@ use crate::{
     input_reader::{InputReader, ResetInput},
 };
 
-/// Instance for [`ActionsMarker`].
+/// Instance for [`InputContext`].
 ///
 /// Stores [`InputAction`]s and evaluates their [`ActionState`] in the order they are bound.
 ///
@@ -48,14 +48,14 @@ use crate::{
 /// [`InputModifier`]: crate::input_modifier::InputModifier
 /// [`Input`]: crate::input::Input
 #[derive(Component)]
-pub struct Actions<M: ActionsMarker> {
+pub struct Actions<C: InputContext> {
     gamepad: GamepadDevice,
     bindings: Vec<ActionBinding>,
     action_map: ActionMap,
-    marker: PhantomData<M>,
+    marker: PhantomData<C>,
 }
 
-impl<M: ActionsMarker> Actions<M> {
+impl<C: InputContext> Actions<C> {
     /// Associates context with gamepad.
     ///
     /// By default it's [`GamepadDevice::Any`].
@@ -168,7 +168,7 @@ impl<M: ActionsMarker> Actions<M> {
     }
 }
 
-impl<M: ActionsMarker> Default for Actions<M> {
+impl<C: InputContext> Default for Actions<C> {
     fn default() -> Self {
         Self {
             gamepad: Default::default(),
@@ -183,13 +183,13 @@ impl<M: ActionsMarker> Default for Actions<M> {
 ///
 /// # Examples
 ///
-/// To implement the trait you can use the [`ActionsMarker`](bevy_enhanced_input_macros::ActionsMarker)
+/// To implement the trait you can use the [`InputContext`](bevy_enhanced_input_macros::InputContext)
 /// derive to reduce boilerplate:
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
-/// #[derive(ActionsMarker)]
+/// #[derive(InputContext)]
 /// struct Player;
 /// ```
 ///
@@ -198,11 +198,11 @@ impl<M: ActionsMarker> Default for Actions<M> {
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
-/// #[derive(ActionsMarker)]
-/// #[actions_marker(priority = 1)]
+/// #[derive(InputContext)]
+/// #[input_context(priority = 1)]
 /// struct Player;
 /// ```
-pub trait ActionsMarker: Send + Sync + 'static {
+pub trait InputContext: Send + Sync + 'static {
     /// Determines the evaluation order of [`Actions<Self>`].
     ///
     /// Ordering is global.
@@ -212,7 +212,7 @@ pub trait ActionsMarker: Send + Sync + 'static {
 
 #[cfg(test)]
 mod tests {
-    use bevy_enhanced_input_macros::{ActionsMarker, InputAction};
+    use bevy_enhanced_input_macros::{InputAction, InputContext};
 
     use super::*;
 
@@ -231,6 +231,6 @@ mod tests {
     #[input_action(output = bool)]
     struct DummyAction;
 
-    #[derive(ActionsMarker)]
+    #[derive(InputContext)]
     struct Dummy;
 }

--- a/src/input_binding.rs
+++ b/src/input_binding.rs
@@ -58,7 +58,7 @@ pub trait BindingBuilder {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_modifiers(Scale::splat(2.0)));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
@@ -73,7 +73,7 @@ pub trait BindingBuilder {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_modifiers((Scale::splat(2.0), Negate::all())));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
@@ -99,7 +99,7 @@ pub trait BindingBuilder {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_conditions(Release::default()));
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
@@ -117,7 +117,7 @@ pub trait BindingBuilder {
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// ```
     #[must_use]
@@ -170,7 +170,7 @@ pub trait IntoBindings {
     ///         GamepadStick::Left.with_modifiers_each(Negate::all()), // Will be applied to each axis.
     ///     ))
     ///     .with_modifiers(DeadZone::default()); // Modifiers like `DeadZone` need to be applied at the action level!
-    /// # #[derive(ActionsMarker)]
+    /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ We provide a [`prelude`] module, which exports most of the typically used traits
 1. Add [`EnhancedInputPlugin`] to your app.
 2. Define gameplay actions as unit structs and implement [`InputAction`] for them.
 3. Define context components and assign actions to them by writing observers for [`Binding`]
-4. Register markers using [`ActionsMarkerAppExt::add_actions_marker`].
+4. Register markers using [`InputContextAppExt::add_input_context`].
 5. Insert actions to entities you want to control.
 6. Create observers to react on [`events`] for each action.
 
@@ -85,10 +85,10 @@ pub mod prelude {
     pub use super::{
         EnhancedInputPlugin, EnhancedInputSystem,
         action_binding::ActionBinding,
-        action_instances::{ActionsMarkerAppExt, Binding, RebuildBindings},
+        action_instances::{Binding, InputContextAppExt, RebuildBindings},
         action_map::{Action, ActionState},
         action_value::{ActionValue, ActionValueDim},
-        actions::{Actions, ActionsMarker},
+        actions::{Actions, InputContext},
         events::*,
         input::{GamepadDevice, Input, InputModKeys, ModKeys},
         input_action::{Accumulation, InputAction},
@@ -103,7 +103,7 @@ pub mod prelude {
         },
         preset::{Bidirectional, Cardinal, GamepadStick},
     };
-    pub use bevy_enhanced_input_macros::{ActionsMarker, InputAction};
+    pub use bevy_enhanced_input_macros::{InputAction, InputContext};
 }
 
 use bevy::{

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -49,7 +49,7 @@ use crate::{
 ///     left: Vec<KeyCode>,
 /// }
 ///
-/// #[derive(ActionsMarker)]
+/// #[derive(InputContext)]
 /// struct Player;
 ///
 /// #[derive(Debug, InputAction)]

--- a/tests/accumulation.rs
+++ b/tests/accumulation.rs
@@ -5,7 +5,7 @@ use bevy_enhanced_input::prelude::*;
 fn max_abs() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -27,7 +27,7 @@ fn max_abs() {
 fn cumulative() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -55,7 +55,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
     actions.bind::<Cumulative>().to(Cardinal::arrow_keys());
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Dummy;
 
 #[derive(Debug, InputAction)]

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -7,7 +7,7 @@ use bevy_enhanced_input::prelude::*;
 fn explicit() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Player>()
+        .add_input_context::<Player>()
         .add_observer(binding)
         .finish();
 
@@ -47,7 +47,7 @@ fn explicit() {
 fn implicit() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Player>()
+        .add_input_context::<Player>()
         .add_observer(binding)
         .finish();
 
@@ -114,7 +114,7 @@ fn implicit() {
 fn blocker() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Player>()
+        .add_input_context::<Player>()
         .add_observer(binding)
         .finish();
 
@@ -181,7 +181,7 @@ fn blocker() {
 fn events_blocker() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Player>()
+        .add_input_context::<Player>()
         .add_observer(binding)
         .finish();
 
@@ -272,7 +272,7 @@ fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Pl
         .with_conditions(BlockBy::<ReleaseAction>::events_only());
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Player;
 
 #[derive(Debug, InputAction)]

--- a/tests/consume_input.rs
+++ b/tests/consume_input.rs
@@ -5,7 +5,7 @@ use bevy_enhanced_input::prelude::*;
 fn consume() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<ConsumeOnly>()
+        .add_input_context::<ConsumeOnly>()
         .add_observer(consume_only_binding)
         .finish();
 
@@ -41,7 +41,7 @@ fn consume() {
 fn passthrough() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<PassthroughOnly>()
+        .add_input_context::<PassthroughOnly>()
         .add_observer(passthrough_only_binding)
         .finish();
 
@@ -86,7 +86,7 @@ fn passthrough() {
 fn consume_then_passthrough() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<ConsumeThenPassthrough>()
+        .add_input_context::<ConsumeThenPassthrough>()
         .add_observer(consume_then_passthrough_binding)
         .finish();
 
@@ -119,7 +119,7 @@ fn consume_then_passthrough() {
 fn passthrough_then_consume() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<PassthroughThenConsume>()
+        .add_input_context::<PassthroughThenConsume>()
         .add_observer(passthrough_then_consume_binding)
         .finish();
 
@@ -178,16 +178,16 @@ fn passthrough_then_consume_binding(
     actions.bind::<Consume>().to(KEY);
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct PassthroughOnly;
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct ConsumeOnly;
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct PassthroughThenConsume;
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct ConsumeThenPassthrough;
 
 /// A key used by both [`Consume`] and [`Passthrough`] actions.

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -5,7 +5,7 @@ use bevy_enhanced_input::prelude::*;
 fn any() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<AnyGamepad>()
+        .add_input_context::<AnyGamepad>()
         .add_observer(any_gamepad_binding)
         .finish();
 
@@ -46,7 +46,7 @@ fn any() {
 fn by_id() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<SingleGamepad>()
+        .add_input_context::<SingleGamepad>()
         .add_observer(single_gamepad_binding)
         .finish();
 
@@ -106,10 +106,10 @@ fn single_gamepad_binding(
     actions.bind::<DummyAction>().to(DummyAction::BUTTON);
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct AnyGamepad;
 
-#[derive(Component, Deref, ActionsMarker)]
+#[derive(Component, Deref, InputContext)]
 struct SingleGamepad(Entity);
 
 #[derive(Debug, InputAction)]

--- a/tests/dim.rs
+++ b/tests/dim.rs
@@ -5,7 +5,7 @@ use bevy_enhanced_input::prelude::*;
 fn bool() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -36,7 +36,7 @@ fn bool() {
 fn axis1d() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -67,7 +67,7 @@ fn axis1d() {
 fn axis2d() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -98,7 +98,7 @@ fn axis2d() {
 fn axis3d() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -133,7 +133,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
     actions.bind::<Axis3D>().to(Axis3D::KEY);
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Dummy;
 
 #[derive(Debug, InputAction)]

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -5,7 +5,7 @@ use bevy_enhanced_input::prelude::*;
 fn removal() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -33,7 +33,7 @@ fn removal() {
 fn rebuild() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -55,7 +55,7 @@ fn rebuild() {
 fn rebuild_all() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -88,7 +88,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
     actions.bind::<DummyAction>().to(DummyAction::KEY);
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Dummy;
 
 #[derive(Debug, InputAction)]

--- a/tests/macro_hygiene.rs
+++ b/tests/macro_hygiene.rs
@@ -11,7 +11,7 @@ use bevy::prelude::{Vec2, Vec3};
 struct InputAction;
 struct Accumulation;
 struct ActionValueDim;
-struct ActionsMarker;
+struct InputContext;
 
 #[derive(Debug, bevy_enhanced_input::prelude::InputAction)]
 #[input_action(output = bool, accumulation = Cumulative)]
@@ -29,5 +29,5 @@ struct Action3;
 #[input_action(output = Vec3)]
 struct Action4;
 
-#[derive(Debug, bevy_enhanced_input::prelude::ActionsMarker)]
+#[derive(Debug, bevy_enhanced_input::prelude::InputContext)]
 struct Marker;

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -5,7 +5,7 @@ use bevy_enhanced_input::prelude::*;
 fn keys() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -50,7 +50,7 @@ fn keys() {
 fn dpad() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -88,7 +88,7 @@ fn dpad() {
 fn sticks() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -144,7 +144,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
     ));
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Dummy;
 
 #[derive(Debug, InputAction)]

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -5,8 +5,8 @@ use bevy_enhanced_input::prelude::*;
 fn prioritization() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<First>()
-        .add_actions_marker::<Second>()
+        .add_input_context::<First>()
+        .add_input_context::<Second>()
         .add_observer(first_binding)
         .add_observer(second_binding)
         .finish();
@@ -56,11 +56,11 @@ fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Act
     actions.bind::<SecondPassthrough>().to(PASSTHROUGH_KEY);
 }
 
-#[derive(ActionsMarker)]
-#[actions_marker(priority = 1)]
+#[derive(InputContext)]
+#[input_context(priority = 1)]
 struct First;
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Second;
 
 /// A key used by both [`FirstConsume`] and [`SecondConsume`] actions.

--- a/tests/require_reset.rs
+++ b/tests/require_reset.rs
@@ -5,8 +5,8 @@ use bevy_enhanced_input::prelude::*;
 fn layering() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<First>()
-        .add_actions_marker::<Second>()
+        .add_input_context::<First>()
+        .add_input_context::<Second>()
         .add_observer(first_binding)
         .add_observer(second_binding)
         .finish();
@@ -63,8 +63,8 @@ fn layering() {
 fn switching() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<First>()
-        .add_actions_marker::<Second>()
+        .add_input_context::<First>()
+        .add_input_context::<Second>()
         .add_observer(first_binding)
         .add_observer(second_binding)
         .finish();
@@ -122,11 +122,11 @@ fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Act
     actions.bind::<DummyAction>().to(DummyAction::KEY);
 }
 
-#[derive(ActionsMarker)]
-#[actions_marker(priority = 1)]
+#[derive(InputContext)]
+#[input_context(priority = 1)]
 struct First;
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Second;
 
 #[derive(Debug, InputAction)]

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -7,7 +7,7 @@ use bevy_enhanced_input::prelude::*;
 fn input_level() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -91,7 +91,7 @@ fn input_level() {
 fn action_level() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -175,7 +175,7 @@ fn action_level() {
 fn both_levels() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_actions_marker::<Dummy>()
+        .add_input_context::<Dummy>()
         .add_observer(binding)
         .finish();
 
@@ -292,7 +292,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
         .with_modifiers(swizzle_axis);
 }
 
-#[derive(ActionsMarker)]
+#[derive(InputContext)]
 struct Dummy;
 
 #[derive(Debug, InputAction)]


### PR DESCRIPTION
While working on a major documentation overhaul, I noticed that `ActionsMarker` is not a good name for a trait.
In my opinion, `InputContext` fits better. Users still mostly work with `Actions`. `InputContext` is just a trait and derive name. I also like that it’s similar to the `InputAction` derive and matches Unreal terminology.

This choice might look clearer once I finish the documentation. So even if we merge this now and come up with a better term after the docs rework - I'm fully open to rename it again :)