### PR TITLE
Documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Dynamic and contextual input mappings for Bevy, inspired by [Unreal Engine Enhan
 ## Features
 
 * Map inputs from various sources (keyboard, gamepad, etc.) to gameplay actions like `Jump`, `Move`, or `Attack`.
-* Assign actions to different contexts like `OnFoot` or `InCar`, which are regular components.
-* Activate or deactivate contexts by simply adding or removing components.
-* Control how actions accumulate input from sources and consume it.
+* Assign actions to different contexts like `OnFoot` or `InCar`, controlled by `Actions<C>` components.
 * Layer multiple contexts on a single entity, controlled by priority.
 * Apply modifiers to inputs, such as dead zones, inversion, scaling, etc., or create custom modifiers by implementing a trait.
 * Assign conditions for how and when an action is triggered, like "hold", "tap", "chord", etc. You can also create custom conditions by implementing a trait.
+* Control how actions accumulate input from sources and consume it.
 * React on actions with observers.
 
 ## Getting Started

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -1,4 +1,4 @@
-//! One context applied on top of another and overrides some of the mappings.
+//! One context applied on top of another and overrides some of the bindings.
 
 mod player_box;
 

--- a/examples/keybinding_menu.rs
+++ b/examples/keybinding_menu.rs
@@ -388,7 +388,7 @@ fn apply(
             // Utilize reflection to write by field name.
             let field_value = settings
                 .path_mut::<Vec<Input>>(field.0)
-                .expect("fields with mappings should be stored as Vec");
+                .expect("fields with bindings should be stored as Vec");
             field_value.push(input);
         }
     }
@@ -442,7 +442,7 @@ fn update_button_background(
 )]
 struct SettingsButton;
 
-/// Stores information about button mapping.
+/// Stores information about button binding.
 #[derive(Component)]
 #[require(SettingsButton)]
 struct InputButton {

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -1,4 +1,4 @@
-//! Two players that use the same context type, but with different mappings.
+//! Two players that use the same context type, but with different bindings.
 
 mod player_box;
 
@@ -64,14 +64,14 @@ fn binding(
 ) {
     let (&player, mut actions) = players.get_mut(trigger.entity()).unwrap();
 
-    // By default context read inputs from all gamepads,
+    // By default actions read inputs from all gamepads,
     // but for local multiplayer we need assign specific
     // gamepad index.
     if let Some(&entity) = gamepads.get(player as usize) {
         actions.set_gamepad(entity);
     }
 
-    // Assign different mappings based player index.
+    // Assign different bindings based player index.
     match player {
         Player::First => {
             actions

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -35,17 +35,17 @@ impl Plugin for GamePlugin {
 fn spawn(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    // Spawn an entity with a component that implements `InputContext`.
+    // Spawn an entity with `Actions` component.
     commands.spawn((PlayerBox, Actions::<Player>::default()));
 }
 
-// To define mappings for actions, write an observer for `Binding`.
+// To define bindings for actions, write an observer for `Binding`.
 // It's also possible to create bindings before the insertion,
 // but this way you can conveniently reload bindings when settings change.
 fn binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Actions<Player>>) {
     let mut actions = players.get_mut(trigger.entity()).unwrap();
 
-    // Mappings like WASD or sticks are very common,
+    // Bindings like WASD or sticks are very common,
     // so we provide built-ins to assign all keys/axes at once.
     // We don't assign any conditions and in this case the action will
     // be triggered with any non-zero value.
@@ -76,7 +76,7 @@ fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>)
     transform.rotate_z(FRAC_PI_4);
 }
 
-// Since it's possible to have multiple input contexts, you need
+// Since it's possible to have multiple `Actions` components, you need
 // to define a marker and derive `InputContext` trait.
 #[derive(InputContext)]
 struct Player;

--- a/src/action_instances.rs
+++ b/src/action_instances.rs
@@ -17,53 +17,10 @@ use crate::{
 
 /// An extension trait for [`App`] to assign input to components.
 pub trait InputContextAppExt {
-    /// Registers `T` an input context marker.
+    /// Registers type `C` as an input context.
     ///
-    /// Necessary to update [`Actions<T>`] components.
-    ///
-    /// Component removal deactivates [`InputContext`] for the entity and trigger transitions for all actions
-    /// to [`ActionState::None`](super::ActionState::None).
-    ///
-    /// Component re-insertion re-triggers [`Binding`]. Use it if you want to reload bindings.
-    /// You can also rebuild all component bindings by triggering [`RebuildBindings`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy::prelude::*;
-    /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut app = App::new();
-    /// # app.add_plugins(EnhancedInputPlugin);
-    /// app.add_input_context::<Player>()
-    ///     .add_observer(player_binding);
-    ///
-    /// fn player_binding(
-    ///     trigger: Trigger<Binding<Player>>,
-    ///     settings: Res<AppSettings>,
-    ///     mut players: Query<&mut Actions<Player>>,
-    /// ) {
-    ///     let mut actions = players.get_mut(trigger.entity()).unwrap();
-    ///     actions
-    ///         .bind::<Jump>()
-    ///         .to((settings.keyboard.jump, GamepadButton::South));
-    /// }
-    ///
-    /// #[derive(InputContext)]
-    /// struct Player;
-    ///
-    /// #[derive(Debug, InputAction)]
-    /// #[input_action(output = bool)]
-    /// struct Jump;
-    ///
-    /// #[derive(Resource)]
-    /// struct AppSettings {
-    ///     keyboard: KeyboardSettings,
-    /// }
-    ///
-    /// struct KeyboardSettings {
-    ///     jump: KeyCode,
-    /// }
-    /// ```
+    /// All structs that implement [`InputContext`] must be registered,
+    /// otherwise [`Actions<C>`] won't be evaluated.
     fn add_input_context<C: InputContext>(&mut self) -> &mut Self;
 }
 
@@ -73,6 +30,11 @@ impl InputContextAppExt for App {
 
         let id = self.world_mut().register_component::<Actions<C>>();
         let mut registry = self.world_mut().resource_mut::<ActionsRegistry>();
+        debug_assert!(
+            !registry.contains(&id),
+            "context `{}` can't be added more then once",
+            any::type_name::<C>()
+        );
         registry.push(id);
 
         self.add_observer(add_context::<C>)
@@ -147,7 +109,7 @@ impl ActionInstances {
 
     fn add<C: InputContext>(&mut self, commands: &mut Commands, entity: Entity) {
         debug!(
-            "adding input context for `{}` to `{entity}`",
+            "adding input context `{}` to `{entity}`",
             any::type_name::<C>(),
         );
 
@@ -177,7 +139,7 @@ impl ActionInstances {
         entity: Entity,
     ) {
         debug!(
-            "removing input context for `{}` from `{}`",
+            "removing input context `{}` from `{}`",
             any::type_name::<C>(),
             entity
         );
@@ -247,7 +209,7 @@ impl ActionsInstance {
         actions: &mut Query<FilteredEntityMut>,
     ) {
         trace!(
-            "updating bindings for `{}` on `{}`",
+            "updating input context `{}` on `{}`",
             any::type_name::<C>(),
             self.entity
         );
@@ -269,7 +231,7 @@ impl ActionsInstance {
         actions: &mut Query<FilteredEntityMut>,
     ) {
         debug!(
-            "resetting bindings for `{}` on `{}`",
+            "resetting input context `{}` on `{}`",
             any::type_name::<C>(),
             self.entity
         );

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -11,10 +11,12 @@ use crate::{
     input_action::{ActionOutput, InputAction},
 };
 
-/// Map for actions to their data.
+/// Maps [`InputAction`] markers to their data.
 ///
-/// Can be accessed from [`InputCondition::evaluate`](crate::input_condition::InputCondition::evaluate)
-/// or [`Actions`](crate::actions::Actions).
+/// Stored inside [`Actions`](crate::actions::Actions).
+///
+/// Accessible from [`InputCondition::evaluate`](crate::input_condition::InputCondition::evaluate)
+/// and [`InputModifier::apply`](crate::input_modifier::InputModifier::apply)
 #[derive(Default, Deref, DerefMut)]
 pub struct ActionMap(pub HashMap<TypeId, Action>);
 
@@ -32,9 +34,13 @@ impl ActionMap {
     }
 }
 
-/// Tracker for action state.
+/// Data associated with an [`InputAction`] marker.
 ///
 /// Stored inside [`ActionMap`].
+///
+/// This struct could also be created manually to track state for an action
+/// with externally sourced data (e.g., network). Use [`Self::update`] to apply
+/// the data followed by [`Self::trigger_events`].
 #[derive(Clone, Copy)]
 pub struct Action {
     state: ActionState,
@@ -90,7 +96,7 @@ impl Action {
 
     /// Triggers events resulting from a state transition after [`Self::update`].
     ///
-    /// See also [`Self::new`].
+    /// See also [`Self::new`] and [`ActionEvents`].
     pub fn trigger_events(&self, commands: &mut Commands, entity: Entity) {
         (self.trigger_events)(self, commands, entity);
     }
@@ -171,6 +177,9 @@ impl Action {
     }
 
     /// Returns the value since the last update.
+    ///
+    /// Unlike when reading values from triggers, this returns [`ActionValue`] since actions
+    /// are stored in a type-erased format.
     pub fn value(&self) -> ActionValue {
         self.value
     }
@@ -198,7 +207,7 @@ fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, entity: Entity,
 ///
 /// States are ordered by their significance.
 ///
-/// See also [`ActionEvents`].
+/// See also [`ActionEvents`] and [`ActionBinding`]().
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ActionState {
     /// Condition is not triggered.

--- a/src/action_value.rs
+++ b/src/action_value.rs
@@ -3,7 +3,9 @@ use core::fmt::Debug;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// Value for [`Input`](crate::input::Input).
+/// Value from [`Input`](crate::input::Input) for [`Action`](crate::action_map::Action).
+///
+/// Can be optionally modified by [`InputModifier`](crate::input_modifier::InputModifier)
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
 pub enum ActionValue {
     Bool(bool),

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,10 +8,9 @@ use crate::{action_map::ActionState, input_action::InputAction};
 bitflags! {
     /// Bitset with events triggered by updating [`ActionState`] for an action.
     ///
-    /// Stored inside [`Action`](super::input_action::Action).
+    /// Stored inside [`Action`](crate::action_map::Action).
     ///
-    /// Actual events can be accessed from observers.
-    /// See [`InputAction`](super::input_action::InputAction) for details.
+    /// On transition events will be triggered with dedicated types that correspond to bitflags.
     ///
     /// Table of state transitions:
     ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,8 +7,7 @@ use bevy::prelude::*;
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
-/// Inputs that can be associated with an
-/// [`InputAction`](super::input_action::InputAction).
+/// Wraps input from any source.
 ///
 /// [Input modifiers](super::input_modifier) can change the captured dimension.
 ///
@@ -245,16 +244,6 @@ pub enum GamepadDevice {
     Any,
     /// Matches input from specific gamepad.
     Single(Entity),
-}
-
-impl GamepadDevice {
-    /// Returns `true` if this device matches the specified gamepad entity.
-    pub fn matches(self, gamepad_entity: Entity) -> bool {
-        match self {
-            GamepadDevice::Any => true,
-            GamepadDevice::Single(entity) => entity == gamepad_entity,
-        }
-    }
 }
 
 impl From<Entity> for GamepadDevice {

--- a/src/input_action.rs
+++ b/src/input_action.rs
@@ -6,34 +6,7 @@ use crate::action_value::{ActionValue, ActionValueDim};
 
 /// Marker for a gameplay-related action.
 ///
-/// Needs to be bind inside observer for [`Binding`](super::action_instances::Binding).
-///
-/// Each binded action will have [`ActionState`](super::action_map::ActionState).
-/// When it updates during [`Actions`](super::actions::Actions)
-/// evaluation, [`events`](super::events) are triggered.
-///
-/// # Examples
-///
-/// Use observers to react on them:
-///
-/// ```
-/// use bevy::prelude::*;
-/// use bevy_enhanced_input::prelude::*;
-///
-/// fn move_character(trigger: Trigger<Fired<Move>>, mut transforms: Query<&mut Transform>) {
-///    let mut transform = transforms.get_mut(trigger.entity()).unwrap();
-///
-///    // Since `Move` has `output = Vec2`, the value is `Vec2`.
-///    // The value of the Z axis will be zero.
-///    transform.translation += trigger.value.extend(0.0);
-/// }
-///
-/// #[derive(Debug, InputAction)]
-/// #[input_action(output = Vec2)]
-/// struct Move;
-/// ```
-///
-/// You can also obtain the state directly from [`Actions`](super::actions::Actions) component.
+/// Needs to be bound to actions using [`Actions::bind`](crate::actions::Actions::bind).
 ///
 /// To implement the trait you can use the [`InputAction`](bevy_enhanced_input_macros::InputAction)
 /// derive to reduce boilerplate:
@@ -55,6 +28,8 @@ use crate::action_value::{ActionValue, ActionValueDim};
 /// #[input_action(output = Vec2, accumulation = Cumulative, consume_input = false)]
 /// struct Move;
 /// ```
+///
+/// All parameters match corresponding data in the trait.
 pub trait InputAction: Debug + Send + Sync + 'static {
     /// What type of value this action will output.
     ///
@@ -62,17 +37,17 @@ pub trait InputAction: Debug + Send + Sync + 'static {
     /// - Use [`f32`] for single-axis actions (e.g., `Zoom`).
     /// - For multi-axis actions, like `Move`, use [`Vec2`] or [`Vec3`].
     ///
-    /// The type here will determine the type of the `value` field on events
-    /// e.g. [`Fired::value`](super::events::Fired::value),
-    /// [`Canceled::value`](super::events::Canceled::value).
+    /// This type will also be used for `value` field on events
+    /// e.g. [`Fired::value`](crate::events::Fired::value),
+    /// [`Canceled::value`](crate::events::Canceled::value).
     type Output: ActionOutput;
 
     /// Specifies whether this action should swallow any [`Input`](crate::input::Input)s
     /// bound to it or allow them to pass through to affect other actions.
     ///
     /// Inputs are consumed only if the action state is not equal to
-    /// [`ActionState::None`](super::action_map::ActionState::None).
-    /// For details, see [`Actions`](super::actions::Actions).
+    /// [`ActionState::None`](crate::action_map::ActionState::None).
+    /// For details, see [`Actions`](crate::actions::Actions).
     ///
     /// Consuming is global and affect actions in all contexts.
     const CONSUME_INPUT: bool = true;
@@ -147,8 +122,8 @@ impl ActionOutput for Vec3 {
 }
 
 /// Defines how [`ActionValue`] is calculated when multiple inputs are evaluated with the
-/// same most significant [`ActionState`](super::action_map::ActionState)
-/// (excluding [`ActionState::None`](super::action_map::ActionState::None)).
+/// same most significant [`ActionState`](crate::action_map::ActionState)
+/// (excluding [`ActionState::None`](crate::action_map::ActionState::None)).
 #[derive(Default, Clone, Copy, Debug)]
 pub enum Accumulation {
     /// Cumulatively add the key values for each mapping.

--- a/src/input_binding.rs
+++ b/src/input_binding.rs
@@ -16,8 +16,8 @@ pub struct InputBinding {
 
     /// Whether the input output a non-zero value.
     ///
-    /// Needed to prevent newly created contexts from reacting to currently
-    /// held inputs until they are released.
+    /// Prevents newly created contexts from reacting to currently held inputs
+    /// until they’re released.
     ///
     /// Used only if [`ActionBinding`](super::action_binding::ActionBinding::require_reset) is set.
     pub(crate) first_activation: bool,

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -19,6 +19,7 @@ use crate::{
     action_value::ActionValue,
 };
 
+/// Default actuation threshold for all conditions.
 pub const DEFAULT_ACTUATION: f32 = 0.5;
 
 /// Defines how input activates.

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -86,7 +86,7 @@ impl InputReader<'_, '_> {
         *self.gamepad_device = gamepad.into();
     }
 
-    /// Returns the [`ActionValue`] for the given [`Input`] if exists.
+    /// Returns the [`ActionValue`] for the given [`Input`].
     ///
     /// See also [`Self::consume`] and [`Self::set_gamepad`].
     pub(crate) fn value(&self, input: impl Into<Input>) -> ActionValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,286 @@
 /*!
-Dynamic and contextual input mappings inspired by [Unreal Engine Enhanced Input](https://dev.epicgames.com/documentation/en-us/unreal-engine/enhanced-input-in-unreal-engine) for Bevy.
-
-# What makes Enhanced Input... enhanced?
-
-Instead of directly reacting to inputs from various sources (like keyboard, gamepad, etc.), you assign inputs to gameplay actions
-like `Move` or `Jump`, which are just unit structs markers. Actions are assigned to contexts, which are components that represent the current
-state of the player character, like `OnFoot` or `InCar`.
-
-For example, if you have a player character that can be on foot or drive a car, you can swap the context to have the same keys
-perform different actions. On foot, pressing Space makes the character jump, while when driving, the same key acts as a brake.
-
-Entities can have any number of contexts, with evaluation order controlled by a defined priority. Actions can also consume inputs,
-allowing you to layer behaviors on top of each other.
-
-Instead of reacting to raw input data like "Released" or "Pressed", the crate provides modifiers and conditions.
-
-[`Modifiers`](input_modifier) let you change the input before passing it to the action. We provide common modifiers,
-like [`DeadZone`], [`Negate`], etc., but you can add your own by implementing [`InputModifier`].
-
-[`Conditions`](input_condition) define how an action activates. We also provide built-in conditions, such as [`Press`],
-[`Release`], [`Hold`], etc. You can also add your own by implementing [`InputCondition`].
+Input manager inspired by [Unreal Engine Enhanced Input](https://dev.epicgames.com/documentation/en-us/unreal-engine/enhanced-input-in-unreal-engine) for Bevy.
 
 # Quick start
 
+## Prelude
+
 We provide a [`prelude`] module, which exports most of the typically used traits and types.
 
-1. Add [`EnhancedInputPlugin`] to your app.
-2. Define gameplay actions as unit structs and implement [`InputAction`] for them.
-3. Define context components and assign actions to them by writing observers for [`Binding`]
-4. Register markers using [`InputContextAppExt::add_input_context`].
-5. Insert actions to entities you want to control.
-6. Create observers to react on [`events`] for each action.
+## Plugins
 
-For more details, see the documentation on relevant types. You can also find examples in the repository.
+Add [`EnhancedInputPlugin`] to your app:
+
+```
+use bevy::prelude::*;
+use bevy_enhanced_input::prelude::*;
+
+let mut app = App::new();
+app.add_plugins((MinimalPlugins, EnhancedInputPlugin));
+```
+
+## Defining actions
+
+Actions represented by unit structs that implement the [`InputAction`] trait, which also requires
+[`Debug`] which we use for logging. You can use the provided derive macro for this.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+#[derive(Debug, InputAction)]
+#[input_action(output = bool)]
+struct Jump;
+
+#[derive(Debug, InputAction)]
+#[input_action(output = Vec2)]
+struct Move;
+```
+
+The `output` defines the [`InputAction::Output`] type and is the only required parameter. See the [`InputAction`]
+documentation for all parameters.
+
+## Defining input contexts
+
+Actions are bound to input contexts. Depending on your type of game, you may have a single global context or multiple
+contexts for different gameplay states. Consider contexts as sets of gameplay actions.
+
+Input contexts are represented by unit structs that implement the [`InputContext`] trait. You can use the provided derive
+macro for this. Unlike actions, all contexts need to be registered in the app using [`InputContextAppExt::add_input_context`].
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+# let mut app = App::new();
+# app.add_plugins(EnhancedInputPlugin);
+app.add_input_context::<OnFoot>();
+
+#[derive(InputContext)]
+struct OnFoot;
+```
+
+No required parameters needed. See the [`InputContext`] documentation for all parameters.
+
+## Binding actions
+
+While input contexts are defined statically at compile time, mappings must be assigned at runtime. They're stored inside the
+[`Actions<C>`] component, where `C` is an input context. Contexts becomes becomes active only when its component exists on an
+entity. You can attach multiple [`Actions<C>`] components to a single entity.
+
+To bind actions, use [`Actions::bind`] followed by one or more [`ActionBinding::to`] calls to define inputs. You can pass any
+input type that implements [`IntoBindings`], including tuples for multiple inputs (similar to [`App::add_systems`] in Bevy).
+All assigned inputs will be treated as "any of". See [`ActionBinding::to`] for details.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+let mut actions = Actions::<OnFoot>::default();
+// The action will trigger when space or gamepad south button is pressed.
+actions.bind::<Jump>().to((KeyCode::Space, GamepadButton::South));
+# #[derive(InputContext)]
+# struct OnFoot;
+# #[derive(Debug, InputAction)]
+# #[input_action(output = bool)]
+# struct Jump;
+```
+
+### Input modifiers
+
+Input is read as the [`ActionValue`] enum, with the variant depending on the input source. See the [`Input`] documentation for
+how each source is captured.
+
+Actions knows nothing about input sources and simply convert values using [`ActionValue::convert`] into the dimension of the
+bound action's output type. However, you might want to apply preprocessing first. For example, invert values, apply sensitivity,
+or remap axes. This is where [input modifiers](crate::input_modifier) come in.
+
+These are structs that implement the [`InputModifier`] trait. You can attach modifiers to inputs using [`BindingBuilder::with_modifiers`].
+Thanks to traits, this works with any input type. You can also attach modifiers globally via [`ActionBinding::with_modifiers`],
+which applies to all inputs. For details about how multiple modifiers are merged together, see the [`ActionBinding`] documentation.
+Both methods also support tuple syntax for assigning multiple modifiers at once.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+# let mut actions = Actions::<OnFoot>::default();
+actions.bind::<Move>().to((
+    // Keyboard keys captured as `bool`, but the output of `Move` is defined as `Vec2`,
+    // so you need to assign keys to axes using swizzle and negation.
+    KeyCode::KeyW.with_modifiers(SwizzleAxis::YXZ),
+    KeyCode::KeyA.with_modifiers(Negate::all()),
+    KeyCode::KeyS.with_modifiers((Negate::all(), SwizzleAxis::YXZ)),
+    KeyCode::KeyD,
+    // In Bevy sticks split by axes and captured as 1-dimensional inputs,
+    // so Y stick needs to be sweezled into Y axis.
+    GamepadAxis::RightStickX,
+    GamepadAxis::RightStickY.with_modifiers(SwizzleAxis::YXZ),
+));
+# #[derive(InputContext)]
+# struct OnFoot;
+# #[derive(Debug, InputAction)]
+# #[input_action(output = Vec2)]
+# struct Move;
+```
+
+You can also attach modifiers to input tuples using [`IntoBindings::with_modifiers_each`]. It works similarly to
+[`IntoSystemConfigs::distributive_run_if`] in Bevy.
+
+### Presets
+
+Some bindings are very common. It would be inconvenient to bind WASD and sticks like in the example above every time.
+To solve this, we provide [presets](crate::preset) - structs that store bindings and apply predefined modifiers.
+They implement [`IntoBindings`], so you can pass them directly into [`ActionBinding::to`].
+
+For example, you can use [`Cardinal`] and [`GamepadStick`] presets to simplify the example above.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+# let mut actions = Actions::<OnFoot>::default();
+// We provide a `with_wasd` method for quick prototyping, but you can
+// construct this struct with any input.
+actions.bind::<Move>().to((Cardinal::wasd_keys(), GamepadStick::Right));
+# #[derive(InputContext)]
+# struct OnFoot;
+# #[derive(Debug, InputAction)]
+# #[input_action(output = Vec2)]
+# struct Move;
+```
+
+### Input conditions
+
+Instead of hardcoded states like "pressed" or "released", all actions internally have an abstract [`ActionState`].
+Its meaning depends on assigned [input conditions](crate::input_condition), which decide when the action triggers.
+This allows to define flexible conditions, such as "hold for 1 second".
+
+Input conditions are structs that implement [`InputCondition`]. Similar to modifiers, you can use
+[`BindingBuilder::with_conditions`] for per-input conditions or [`ActionBinding::with_conditions`]
+to define a condition that applies to all action's inputs. Conditions evaluated after input modifiers.
+For details about how multiple conditions are merged together, see the [`ActionBinding`] documentation.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+# let mut actions = Actions::<OnFoot>::default();
+// The action will trigger only if held for 1 second.
+actions.bind::<Jump>().to(KeyCode::Space.with_conditions(Hold::new(1.0)));
+# #[derive(InputContext)]
+# struct OnFoot;
+# #[derive(Debug, InputAction)]
+# #[input_action(output = bool)]
+# struct Jump;
+```
+
+If no conditions are assigned, the action will be triggered by any non-zero value.
+
+Similar to modifiers, you can also attach conditions to input tuples using [`IntoBindings::with_conditions_each`].
+
+### Organizing bindings
+
+It's convenient to define bindings in a single function that used every time you activate the context
+or reload your application settings.
+
+To achieve this, we provide a special [`Binding<C>`] event that triggers when you insert or replace
+[`Actions<C>`] component. Just create an observer for it and define all your bindings there:
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+# let mut app = App::new();
+app.add_observer(bind_actions);
+
+/// Setups bindings for [`OnFoot`] context from application settings.
+fn bind_actions(
+    trigger: Trigger<Binding<OnFoot>>,
+    settings: Res<AppSettings>,
+    mut actions: Query<&mut Actions<OnFoot>>
+) {
+    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    actions
+        .bind::<Jump>()
+        .to((settings.keyboard.jump, GamepadButton::South));
+}
+
+#[derive(Resource)]
+struct AppSettings {
+    keyboard: KeyboardSettings,
+}
+
+struct KeyboardSettings {
+    jump: KeyCode,
+}
+# #[derive(InputContext)]
+# struct OnFoot;
+# #[derive(Debug, InputAction)]
+# #[input_action(output = bool)]
+# struct Jump;
+```
+
+We also provide a user-triggerable [`RebuildBindings`] event that resets bindings for all inserted
+[`Actions`] and also triggers [`Binding`] event for them.
+
+## Reacting on actions
+
+Up to this point, we've only defined actions and contexts but haven't reacted to them yet.
+We provide both push-style (via observers) and pull-style (by checking components) APIs.
+
+### Push-style
+
+It's recommended to always use the observer API when possible. Don’t worry about losing parallelism - running a system
+has its own overhead, so for small logic, it’s actually faster to execute it outside a system. Just avoid heavy logic in
+action observers.
+
+After each input processing cycle, we calculate a new [`ActionState`] and trigger events based on state transition
+(including transition between identical states). For details about transition logic and event types, see the [`ActionEvents`]
+documentation.
+
+Triggered events are stored as [`ActionEvents`] bitset, but triggered using dedicated types that correspond to bitflags -
+[`Started<A>`], [`Fired<A>`], etc., where `A` is your action type. The trigger target will be the entity with the [`Actions`] component
+and the output type will match the action’s [`InputAction::Output`]. Events also store other information, such as timings. See the
+documentation on specific event type for more information.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+# let mut app = App::new();
+app.add_observer(apply_movement);
+
+/// Apply movemenet when `Move` action considered fired.
+fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
+    // Read transform from the context entity.
+    let mut transform = players.get_mut(trigger.entity()).unwrap();
+
+    // We defined the output of `Move` as `Vec2`,
+    // but since translation expects `Vec3`, we extend it to 3 axes.
+    transform.translation += trigger.value.extend(0.0);
+}
+# #[derive(Debug, InputAction)]
+# #[input_action(output = Vec2)]
+# struct Move;
+```
+
+The event system is highly flexible. For example, you can use the [`Hold`] condition for an attack action, triggering strong attacks on
+[`Completed`] events and regular attacks on [`Canceled`] events.
+
+### Pull-style
+
+You can also query for [`Actions`] within a system. Use [`Actions::action<A>`] to retrieve an [`Action`], from which you can obtain the
+current value, state, or triggered events for this tick as [`ActionEvents`] bitset.
+
+```
+# use bevy::prelude::*;
+# use bevy_enhanced_input::prelude::*;
+/// Apply movemenet when `Move` action considered fired.
+fn system(players: Single<(&Actions<OnFoot>, &mut Transform)>) {
+    let (actions, mut transform) = players.into_inner();
+    if actions.action::<Jump>().state() == ActionState::Fired {
+        // Apply logic...
+    }
+}
+# #[derive(InputContext)]
+# struct OnFoot;
+# #[derive(Debug, InputAction)]
+# #[input_action(output = bool)]
+# struct Jump;
+```
 
 # Input and UI
 

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -157,9 +157,10 @@ impl<I: IntoBindings> IntoBindings for Bidirectional<I> {
     }
 }
 
-/// A preset to map a stick as 1-dimensional input.
+/// A preset for mapping a stick as 2-dimensional input.
 ///
-/// Represents the side of a gamepad's analog stick.
+/// In Bevy, sticks are split by axes and captured as 1-dimensional inputs.
+/// This preset maps stick axes to X and Y using [`SwizzleAxis`].
 #[derive(Debug, Clone, Copy)]
 pub enum GamepadStick {
     /// Corresponds to [`GamepadAxis::LeftStickX`] and [`GamepadAxis::LeftStickY`]


### PR DESCRIPTION
- Add a quick start guide that walks users through the API.
- Refine documentation on all types and ensure that it attached to a proper type after countless refactoring.
- Minor logging adjustments to use consistent terminology.