### PR TITLE
Update to Bevy 0.16 RC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
   codecov:
     name: Upload to Codecov
     if: github.actor != 'dependabot[bot]'
-    needs: [typos, format, lint, doctest, test]
+    needs: [typos, format, lint, no-std-portable-atomic, doctest, test]
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,25 @@ jobs:
       - name: Rustdoc
         run: cargo rustdoc -- -D warnings
 
+  no-std-portable-atomic:
+    name: Without atomics and std
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      # Use the same target platform as Bevy (Game Boy Advance).
+      - name: Instal stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv6m-none-eabi
+
+      - name: Cache crates
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check compilation
+        run: cargo check --target thumbv6m-none-eabi --features bevy/critical-section
+
   doctest:
     name: Doctest
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to Bevy 0.16.
+
 ## [0.9.0] - 2025-04-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enhanced_input"
-version = "0.10.0-rc.4"
+version = "0.10.0-rc.5"
 authors = ["Hennadii Chernyshchyk <genaloner@gmail.com>"]
 edition = "2024"
 description = "Input manager for Bevy, inspired by Unreal Engine Enhanced Input"
@@ -12,8 +12,8 @@ license = "MIT OR Apache-2.0"
 include = ["/src", "/LICENSE*"]
 
 [dependencies]
-bevy_enhanced_input_macros = { path = "macros", version = "0.10.0-rc.4" }
-bevy = { version = "0.16.0-rc.4", default-features = false, features = [
+bevy_enhanced_input_macros = { path = "macros", version = "0.10.0-rc.5" }
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
   "serialize",
 ] }
 log = "0.4" # Directly depend on `log` like other `no_std` Bevy crates, since `bevy_log` currently requires `std`.
@@ -22,10 +22,10 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.6", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.4", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
   "bevy_gilrs",
   "bevy_gizmos",
-  "tracing",
+  "bevy_log",
   "bevy_ui_picking_backend",
   "bevy_ui",
   "bevy_window",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enhanced_input"
-version = "0.9.0"
+version = "0.10.0-rc.3"
 authors = ["Hennadii Chernyshchyk <genaloner@gmail.com>"]
 edition = "2024"
 description = "Input manager for Bevy, inspired by Unreal Engine Enhanced Input"
@@ -12,17 +12,24 @@ license = "MIT OR Apache-2.0"
 include = ["/src", "/LICENSE*"]
 
 [dependencies]
-bevy_enhanced_input_macros = { path = "macros", version = "0.9.0" }
-bevy = { version = "0.15", default-features = false, features = ["serialize"] }
+bevy_enhanced_input_macros = { path = "macros", version = "0.10.0-rc.3" }
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+  "serialize",
+] }
+log = "0.4" # Directly depend on `log` like other `no_std` Bevy crates, since `bevy_log` currently requires `std`.
+variadics_please = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.6", features = ["serde"] }
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
   "bevy_gilrs",
-  "bevy_ui",
   "bevy_gizmos",
+  "bevy_log",
+  "bevy_ui_picking_backend",
+  "bevy_ui",
   "bevy_window",
+  "default_font",
   "x11",
 ] }
 ron = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bevy = { version = "0.16.0-rc.3", default-features = false, features = [
 log = "0.4" # Directly depend on `log` like other `no_std` Bevy crates, since `bevy_log` currently requires `std`.
 variadics_please = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-bitflags = { version = "2.6", features = ["serde"] }
+bitflags = { version = "2.6", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
 bevy = { version = "0.16.0-rc.3", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enhanced_input"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.4"
 authors = ["Hennadii Chernyshchyk <genaloner@gmail.com>"]
 edition = "2024"
 description = "Input manager for Bevy, inspired by Unreal Engine Enhanced Input"
@@ -12,8 +12,8 @@ license = "MIT OR Apache-2.0"
 include = ["/src", "/LICENSE*"]
 
 [dependencies]
-bevy_enhanced_input_macros = { path = "macros", version = "0.10.0-rc.3" }
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy_enhanced_input_macros = { path = "macros", version = "0.10.0-rc.4" }
+bevy = { version = "0.16.0-rc.4", default-features = false, features = [
   "serialize",
 ] }
 log = "0.4" # Directly depend on `log` like other `no_std` Bevy crates, since `bevy_log` currently requires `std`.
@@ -22,10 +22,10 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.6", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.4", default-features = false, features = [
   "bevy_gilrs",
   "bevy_gizmos",
-  "bevy_log",
+  "tracing",
   "bevy_ui_picking_backend",
   "bevy_ui",
   "bevy_window",

--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -33,7 +33,7 @@ fn spawn(mut commands: Commands) {
 }
 
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
         .bind::<PressAction>()
         .to(PressAction::KEY)

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -44,7 +44,7 @@ fn spawn(mut commands: Commands) {
 }
 
 fn regular_binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Actions<Player>>) {
-    let mut actions = players.get_mut(trigger.entity()).unwrap();
+    let mut actions = players.get_mut(trigger.target()).unwrap();
     actions
         .bind::<Move>()
         .to(Cardinal::wasd_keys())
@@ -58,7 +58,7 @@ fn regular_binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Ac
 }
 
 fn swimming_binding(trigger: Trigger<Binding<Swimming>>, mut players: Query<&mut Actions<Player>>) {
-    let mut actions = players.get_mut(trigger.entity()).unwrap();
+    let mut actions = players.get_mut(trigger.target()).unwrap();
     // `Player` has lower priority, so `Dive` and `ExitWater` consume inputs first,
     // preventing `Rotate` and `EnterWater` from being triggered.
     // The consuming behavior can be configured in the `InputAction` trait.
@@ -67,12 +67,12 @@ fn swimming_binding(trigger: Trigger<Binding<Swimming>>, mut players: Query<&mut
 }
 
 fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.translation += trigger.value.extend(0.0);
 }
 
 fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.rotate_z(FRAC_PI_4);
 }
 
@@ -82,21 +82,21 @@ fn enter_water(
     mut players: Query<&mut PlayerColor>,
 ) {
     // Change color for visibility.
-    let mut color = players.get_mut(trigger.entity()).unwrap();
+    let mut color = players.get_mut(trigger.target()).unwrap();
     **color = INDIGO_600.into();
 
     commands
-        .entity(trigger.entity())
+        .entity(trigger.target())
         .insert(Actions::<Swimming>::default());
 }
 
 fn start_diving(trigger: Trigger<Started<Dive>>, mut players: Query<&mut Visibility>) {
-    let mut visibility = players.get_mut(trigger.entity()).unwrap();
+    let mut visibility = players.get_mut(trigger.target()).unwrap();
     *visibility = Visibility::Hidden;
 }
 
 fn end_diving(trigger: Trigger<Completed<Dive>>, mut players: Query<&mut Visibility>) {
-    let mut visibility = players.get_mut(trigger.entity()).unwrap();
+    let mut visibility = players.get_mut(trigger.target()).unwrap();
     *visibility = Visibility::Visible;
 }
 
@@ -105,11 +105,11 @@ fn exit_water(
     mut commands: Commands,
     mut players: Query<&mut PlayerColor>,
 ) {
-    let mut color = players.get_mut(trigger.entity()).unwrap();
+    let mut color = players.get_mut(trigger.target()).unwrap();
     **color = Default::default();
 
     commands
-        .entity(trigger.entity())
+        .entity(trigger.target())
         .remove::<Actions<Swimming>>();
 }
 

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -42,7 +42,7 @@ fn spawn(mut commands: Commands) {
 }
 
 fn foot_binding(trigger: Trigger<Binding<OnFoot>>, mut players: Query<&mut Actions<OnFoot>>) {
-    let mut actions = players.get_mut(trigger.entity()).unwrap();
+    let mut actions = players.get_mut(trigger.target()).unwrap();
     actions
         .bind::<Move>()
         .to(Cardinal::wasd_keys())
@@ -56,7 +56,7 @@ fn foot_binding(trigger: Trigger<Binding<OnFoot>>, mut players: Query<&mut Actio
 }
 
 fn car_binding(trigger: Trigger<Binding<InCar>>, mut players: Query<&mut Actions<InCar>>) {
-    let mut actions = players.get_mut(trigger.entity()).unwrap();
+    let mut actions = players.get_mut(trigger.target()).unwrap();
     actions
         .bind::<Move>()
         .to(Cardinal::wasd_keys())
@@ -69,12 +69,12 @@ fn car_binding(trigger: Trigger<Binding<InCar>>, mut players: Query<&mut Actions
 }
 
 fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.translation += trigger.value.extend(0.0);
 }
 
 fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.rotate_z(FRAC_PI_4);
 }
 
@@ -84,11 +84,11 @@ fn enter_car(
     mut players: Query<&mut PlayerColor>,
 ) {
     // Change color for visibility.
-    let mut color = players.get_mut(trigger.entity()).unwrap();
+    let mut color = players.get_mut(trigger.target()).unwrap();
     **color = FUCHSIA_400.into();
 
     commands
-        .entity(trigger.entity())
+        .entity(trigger.target())
         .remove::<Actions<OnFoot>>()
         .insert(Actions::<InCar>::default());
 }
@@ -98,11 +98,11 @@ fn exit_car(
     mut commands: Commands,
     mut players: Query<&mut PlayerColor>,
 ) {
-    let mut color = players.get_mut(trigger.entity()).unwrap();
+    let mut color = players.get_mut(trigger.target()).unwrap();
     **color = Default::default();
 
     commands
-        .entity(trigger.entity())
+        .entity(trigger.target())
         .remove::<Actions<InCar>>()
         .insert(Actions::<OnFoot>::default());
 }

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -62,7 +62,7 @@ fn binding(
     gamepads: Res<Gamepads>,
     mut players: Query<(&Player, &mut Actions<Player>)>,
 ) {
-    let (&player, mut actions) = players.get_mut(trigger.entity()).unwrap();
+    let (&player, mut actions) = players.get_mut(trigger.target()).unwrap();
 
     // By default actions read inputs from all gamepads,
     // but for local multiplayer we need assign specific
@@ -101,12 +101,12 @@ fn binding(
 }
 
 fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.translation += trigger.value.extend(0.0);
 }
 
 fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.rotate_z(FRAC_PI_4);
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -43,7 +43,7 @@ fn spawn(mut commands: Commands) {
 // It's also possible to create bindings before the insertion,
 // but this way you can conveniently reload bindings when settings change.
 fn binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Actions<Player>>) {
-    let mut actions = players.get_mut(trigger.entity()).unwrap();
+    let mut actions = players.get_mut(trigger.target()).unwrap();
 
     // Bindings like WASD or sticks are very common,
     // so we provide built-ins to assign all keys/axes at once.
@@ -66,13 +66,13 @@ fn binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Actions<Pl
 }
 
 fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     // The value has already been preprocessed by defined modifiers.
     transform.translation += trigger.value.extend(0.0);
 }
 
 fn rotate(trigger: Trigger<Started<Rotate>>, mut players: Query<&mut Transform>) {
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
     transform.rotate_z(FRAC_PI_4);
 }
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enhanced_input_macros"
-version = "0.10.0-rc.4"
+version = "0.10.0-rc.5"
 authors = ["Hennadii Chernyshchyk <genaloner@gmail.com>"]
 edition = "2021"
 description = "Bevy Enhanced Input Macros"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enhanced_input_macros"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.4"
 authors = ["Hennadii Chernyshchyk <genaloner@gmail.com>"]
 edition = "2021"
 description = "Bevy Enhanced Input Macros"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_enhanced_input_macros"
-version = "0.9.0"
+version = "0.10.0-rc.3"
 authors = ["Hennadii Chernyshchyk <genaloner@gmail.com>"]
 edition = "2021"
 description = "Bevy Enhanced Input Macros"

--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -5,6 +5,7 @@ use core::{
 };
 
 use bevy::prelude::*;
+use log::{debug, trace};
 
 use crate::{
     action_map::{ActionMap, ActionState},

--- a/src/action_instances.rs
+++ b/src/action_instances.rs
@@ -9,6 +9,7 @@ use bevy::{
     ecs::{component::ComponentId, world::FilteredEntityMut},
     prelude::*,
 };
+use log::{debug, trace};
 
 use crate::{
     actions::{Actions, InputContext},
@@ -56,7 +57,7 @@ fn add_context<C: InputContext>(
     mut commands: Commands,
     mut instances: ResMut<ActionInstances>,
 ) {
-    instances.add::<C>(&mut commands, trigger.entity());
+    instances.add::<C>(&mut commands, trigger.target());
 }
 
 fn remove_context<C: InputContext>(
@@ -72,7 +73,7 @@ fn remove_context<C: InputContext>(
         &mut reset_input,
         &time,
         &mut actions,
-        trigger.entity(),
+        trigger.target(),
     );
 }
 

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -3,7 +3,8 @@ use core::{
     fmt::Debug,
 };
 
-use bevy::{prelude::*, utils::HashMap};
+use bevy::{platform_support::collections::HashMap, prelude::*};
+use log::debug;
 
 use crate::{
     action_value::ActionValue,

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -3,7 +3,7 @@ use core::{
     fmt::Debug,
 };
 
-use bevy::{platform_support::collections::HashMap, prelude::*};
+use bevy::{platform::collections::HashMap, prelude::*};
 use log::debug;
 
 use crate::{

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -4,7 +4,7 @@ use core::{
     marker::PhantomData,
 };
 
-use bevy::{platform_support::collections::hash_map::Entry, prelude::*};
+use bevy::{platform::collections::hash_map::Entry, prelude::*};
 
 use crate::{
     action_binding::ActionBinding,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -4,7 +4,7 @@ use core::{
     marker::PhantomData,
 };
 
-use bevy::{prelude::*, utils::Entry};
+use bevy::{platform_support::collections::hash_map::Entry, prelude::*};
 
 use crate::{
     action_binding::ActionBinding,

--- a/src/input_binding.rs
+++ b/src/input_binding.rs
@@ -246,7 +246,7 @@ macro_rules! impl_tuple_binds {
     };
 }
 
-bevy::utils::all_tuples!(impl_tuple_binds, 1, 15, I);
+variadics_please::all_tuples!(impl_tuple_binds, 1, 15, I);
 
 /// Bindings with assigned modifiers.
 ///

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -106,4 +106,4 @@ macro_rules! impl_tuple_condition {
     };
 }
 
-bevy::utils::all_tuples!(impl_tuple_condition, 1, 15, I);
+variadics_please::all_tuples!(impl_tuple_condition, 1, 15, I);

--- a/src/input_condition/block_by.rs
+++ b/src/input_condition/block_by.rs
@@ -1,6 +1,7 @@
 use core::{any, marker::PhantomData};
 
 use bevy::prelude::*;
+use log::warn;
 
 use super::{ConditionKind, InputCondition};
 use crate::{
@@ -65,7 +66,8 @@ impl<A: InputAction> InputCondition for BlockBy<A> {
                 return ActionState::None;
             }
         } else {
-            warn_once!(
+            // TODO: use `warn_once` when `bevy_log` becomes `no_std` compatible.
+            warn!(
                 "action `{}` is not present in context",
                 any::type_name::<A>()
             );

--- a/src/input_condition/chord.rs
+++ b/src/input_condition/chord.rs
@@ -1,6 +1,7 @@
 use core::{any, marker::PhantomData};
 
 use bevy::prelude::*;
+use log::warn;
 
 use super::{ConditionKind, InputCondition};
 use crate::{
@@ -45,7 +46,8 @@ impl<A: InputAction> InputCondition for Chord<A> {
             // Inherit state from the chorded action.
             action.state()
         } else {
-            warn_once!(
+            // TODO: use `warn_once` when `bevy_log` becomes `no_std` compatible.
+            warn!(
                 "action `{}` is not present in context",
                 any::type_name::<A>()
             );

--- a/src/input_modifier.rs
+++ b/src/input_modifier.rs
@@ -64,4 +64,4 @@ macro_rules! impl_tuple_modifiers {
     };
 }
 
-bevy::utils::all_tuples!(impl_tuple_modifiers, 1, 15, I);
+variadics_please::all_tuples!(impl_tuple_modifiers, 1, 15, I);

--- a/src/input_modifier/accumulate_by.rs
+++ b/src/input_modifier/accumulate_by.rs
@@ -1,6 +1,7 @@
 use core::{any, marker::PhantomData};
 
 use bevy::prelude::*;
+use log::warn;
 
 use super::InputModifier;
 use crate::{
@@ -46,7 +47,8 @@ impl<A: InputAction> InputModifier for AccumulateBy<A> {
             }
             ActionValue::Axis3D(self.value).convert(value.dim())
         } else {
-            warn_once!(
+            // TODO: use `warn_once` when `bevy_log` becomes `no_std` compatible.
+            warn!(
                 "action `{}` is not present in context",
                 any::type_name::<A>()
             );

--- a/src/input_modifier/exponential_curve.rs
+++ b/src/input_modifier/exponential_curve.rs
@@ -56,7 +56,7 @@ impl InputModifier for ExponentialCurve {
 }
 
 fn apply_exp(value: f32, exp: f32) -> f32 {
-    value.abs().powf(exp).copysign(value)
+    ops::powf(value.abs(), exp).copysign(value)
 }
 
 #[cfg(test)]

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -4,8 +4,8 @@ use core::hash::Hash;
 use bevy::{
     ecs::system::SystemParam,
     input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll},
+    platform_support::collections::HashSet,
     prelude::*,
-    utils::HashSet,
 };
 
 use crate::{

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -4,7 +4,7 @@ use core::hash::Hash;
 use bevy::{
     ecs::system::SystemParam,
     input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll},
-    platform_support::collections::HashSet,
+    platform::collections::HashSet,
     prelude::*,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ actions.bind::<Move>().to((
 ```
 
 You can also attach modifiers to input tuples using [`IntoBindings::with_modifiers_each`]. It works similarly to
-[`IntoSystemConfigs::distributive_run_if`] in Bevy.
+[`IntoScheduleConfigs::distributive_run_if`] in Bevy.
 
 ### Presets
 
@@ -307,7 +307,7 @@ RUST_LOG=bevy_enhanced_input=debug cargo run
 
 The exact method depends on the OS shell.
 
-Alternatively you can configure [`LogPlugin`](bevy::log::LogPlugin) to make it permanent.
+Alternatively you can configure `LogPlugin` to make it permanent.
 */
 
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ fn bind_actions(
     settings: Res<AppSettings>,
     mut actions: Query<&mut Actions<OnFoot>>
 ) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
         .bind::<Jump>()
         .to((settings.keyboard.jump, GamepadButton::South));
@@ -254,7 +254,7 @@ app.add_observer(apply_movement);
 /// Apply movement when `Move` action considered fired.
 fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transform>) {
     // Read transform from the context entity.
-    let mut transform = players.get_mut(trigger.entity()).unwrap();
+    let mut transform = players.get_mut(trigger.target()).unwrap();
 
     // We defined the output of `Move` as `Vec2`,
     // but since translation expects `Vec3`, we extend it to 3 axes.
@@ -311,8 +311,6 @@ Alternatively you can configure [`LogPlugin`](bevy::log::LogPlugin) to make it p
 */
 
 #![no_std]
-
-extern crate std;
 
 extern crate alloc;
 

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -29,7 +29,7 @@ use crate::{
 ///     settings: Res<KeyboardSettings>,
 ///     mut players: Query<&mut Actions<Player>>,
 /// ) {
-///     let mut actions = players.get_mut(trigger.entity()).unwrap();
+///     let mut actions = players.get_mut(trigger.target()).unwrap();
 ///     actions.bind::<Move>().to(Cardinal {
 ///         north: &settings.forward,
 ///         east: &settings.right,

--- a/src/trigger_tracker.rs
+++ b/src/trigger_tracker.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 
 use bevy::prelude::*;
+use log::trace;
 
 use crate::{
     action_map::{ActionMap, ActionState},

--- a/tests/accumulation.rs
+++ b/tests/accumulation.rs
@@ -50,7 +50,7 @@ fn cumulative() {
 }
 
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<MaxAbs>().to(Cardinal::wasd_keys());
     actions.bind::<Cumulative>().to(Cardinal::arrow_keys());
 }

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -250,7 +250,7 @@ fn events_blocker() {
 }
 
 fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Player>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
         .bind::<ReleaseAction>()
         .to(ReleaseAction::KEY)

--- a/tests/consume_input.rs
+++ b/tests/consume_input.rs
@@ -148,7 +148,7 @@ fn consume_only_binding(
     trigger: Trigger<Binding<ConsumeOnly>>,
     mut actions: Query<&mut Actions<ConsumeOnly>>,
 ) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Consume>().to(KEY);
 }
 
@@ -156,7 +156,7 @@ fn passthrough_only_binding(
     trigger: Trigger<Binding<PassthroughOnly>>,
     mut actions: Query<&mut Actions<PassthroughOnly>>,
 ) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Passthrough>().to(KEY);
 }
 
@@ -164,7 +164,7 @@ fn consume_then_passthrough_binding(
     trigger: Trigger<Binding<ConsumeThenPassthrough>>,
     mut actions: Query<&mut Actions<ConsumeThenPassthrough>>,
 ) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Consume>().to(KEY);
     actions.bind::<Passthrough>().to(KEY);
 }
@@ -173,7 +173,7 @@ fn passthrough_then_consume_binding(
     trigger: Trigger<Binding<PassthroughThenConsume>>,
     mut actions: Query<&mut Actions<PassthroughThenConsume>>,
 ) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Passthrough>().to(KEY);
     actions.bind::<Consume>().to(KEY);
 }

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -93,7 +93,7 @@ fn any_gamepad_binding(
     trigger: Trigger<Binding<AnyGamepad>>,
     mut actions: Query<&mut Actions<AnyGamepad>>,
 ) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<DummyAction>().to(DummyAction::BUTTON);
 }
 
@@ -101,7 +101,7 @@ fn single_gamepad_binding(
     trigger: Trigger<Binding<SingleGamepad>>,
     mut actions: Query<(&mut Actions<SingleGamepad>, &mut SingleGamepad)>,
 ) {
-    let (mut actions, gamepad) = actions.get_mut(trigger.entity()).unwrap();
+    let (mut actions, gamepad) = actions.get_mut(trigger.target()).unwrap();
     actions.set_gamepad(**gamepad);
     actions.bind::<DummyAction>().to(DummyAction::BUTTON);
 }

--- a/tests/dim.rs
+++ b/tests/dim.rs
@@ -126,7 +126,7 @@ fn axis3d() {
 }
 
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Bool>().to(Bool::KEY);
     actions.bind::<Axis1D>().to(Axis1D::KEY);
     actions.bind::<Axis2D>().to(Axis2D::KEY);

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -21,8 +21,12 @@ fn removal() {
         .resource_mut::<ButtonInput<KeyCode>>()
         .press(DummyAction::KEY);
 
+    #[allow(
+        clippy::unused_unit,
+        reason = "https://github.com/rust-lang/rust-clippy/issues/14577"
+    )]
     app.world_mut()
-        .add_observer(|_: Trigger<Fired<DummyAction>>| {
+        .add_observer(|_: Trigger<Fired<DummyAction>>| -> () {
             panic!("action shouldn't trigger");
         });
 
@@ -84,7 +88,7 @@ fn rebuild_all() {
 }
 
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<DummyAction>().to(DummyAction::KEY);
 }
 

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -21,12 +21,8 @@ fn removal() {
         .resource_mut::<ButtonInput<KeyCode>>()
         .press(DummyAction::KEY);
 
-    #[allow(
-        clippy::unused_unit,
-        reason = "https://github.com/rust-lang/rust-clippy/issues/14577"
-    )]
     app.world_mut()
-        .add_observer(|_: Trigger<Fired<DummyAction>>| -> () {
+        .add_observer(|_: Trigger<Fired<DummyAction>>| {
             panic!("action shouldn't trigger");
         });
 

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -130,7 +130,7 @@ const DOWN: Vec2 = Vec2::new(0.0, -1.0);
 const RIGHT: Vec2 = Vec2::new(1.0, 0.0);
 
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<DummyAction>().to((
         Cardinal::wasd_keys(),
         Cardinal::arrow_keys(),

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -45,13 +45,13 @@ fn prioritization() {
 }
 
 fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<FirstConsume>().to(CONSUME_KEY);
     actions.bind::<FirstPassthrough>().to(PASSTHROUGH_KEY);
 }
 
 fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Actions<Second>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<SecondConsume>().to(CONSUME_KEY);
     actions.bind::<SecondPassthrough>().to(PASSTHROUGH_KEY);
 }

--- a/tests/require_reset.rs
+++ b/tests/require_reset.rs
@@ -113,12 +113,12 @@ fn switching() {
 }
 
 fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<DummyAction>().to(DummyAction::KEY);
 }
 
 fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Actions<Second>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<DummyAction>().to(DummyAction::KEY);
 }
 

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -256,7 +256,7 @@ fn both_levels() {
 }
 
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
-    let mut actions = actions.get_mut(trigger.entity()).unwrap();
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
 
     let down = Press::default();
     let release = Release::default();


### PR DESCRIPTION
Straightforward migration, except:
- `keybinding_menu` example currently broken due to https://github.com/bevyengine/bevy/issues/18779, but it works on `main`.
- @bushrat011899 previously submitted the preparation to `no_std` support in #52, but for some reason it fails to compile if I enable `serialize` feature on Bevy.

Update: everything fixed on Bevy side with RC 4.