### PR TITLE
Add schedule configuration support to input contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `InputContext::Schedule` to control the schedule in which the context will be evaluated.
+
 ## [0.9.0] - 2025-04-08
 
 ### Added

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -16,8 +16,10 @@ struct InputActionOpts {
 }
 
 #[derive(FromDeriveInput)]
-#[darling(attributes(input_action))]
+#[darling(attributes(input_context))]
 struct InputContextOpts {
+    #[darling(default)]
+    schedule: Option<Ident>,
     #[darling(default)]
     priority: Option<usize>,
 }
@@ -97,11 +99,17 @@ pub fn input_context_derive(item: TokenStream) -> TokenStream {
     } else {
         Default::default()
     };
+    let schedule = if let Some(schedule) = opts.schedule {
+        quote! { #schedule }
+    } else {
+        quote! { ::bevy::app::PreUpdate }
+    };
 
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
     TokenStream::from(quote! {
         impl #impl_generics #InputContext for #struct_name #type_generics #where_clause {
+            type Schedule = #schedule;
             #priority
         }
     })

--- a/src/action_instances.rs
+++ b/src/action_instances.rs
@@ -6,12 +6,18 @@ use core::{
 };
 
 use bevy::{
-    ecs::{component::ComponentId, world::FilteredEntityMut},
+    ecs::{
+        component::ComponentId,
+        schedule::ScheduleLabel,
+        system::{ParamBuilder, QueryParamBuilder},
+        world::FilteredEntityMut,
+    },
     prelude::*,
 };
 use log::{debug, trace};
 
 use crate::{
+    EnhancedInputSystem,
     actions::{Actions, InputContext},
     input_reader::{InputReader, ResetInput},
 };
@@ -27,16 +33,29 @@ pub trait InputContextAppExt {
 
 impl InputContextAppExt for App {
     fn add_input_context<C: InputContext>(&mut self) -> &mut Self {
-        debug!("registering context for `{}`", any::type_name::<C>());
+        debug!(
+            "registering `{}` for `{}`",
+            any::type_name::<C>(),
+            any::type_name::<C::Schedule>(),
+        );
 
         let id = self.world_mut().register_component::<Actions<C>>();
-        let mut registry = self.world_mut().resource_mut::<ActionsRegistry>();
-        debug_assert!(
-            !registry.contains(&id),
-            "context `{}` can't be added more then once",
-            any::type_name::<C>()
-        );
-        registry.push(id);
+        let mut registry = self.world_mut().resource_mut::<ContextRegistry>();
+        if let Some(contexts) = registry
+            .iter_mut()
+            .find(|c| c.schedule_id == TypeId::of::<C::Schedule>())
+        {
+            debug_assert!(
+                !contexts.action_ids.contains(&id),
+                "context `{}` shouldn't be added more then once",
+                any::type_name::<C>()
+            );
+            contexts.action_ids.push(id);
+        } else {
+            let mut contexts = ScheduleContexts::new::<C::Schedule>();
+            contexts.action_ids.push(id);
+            registry.push(contexts);
+        }
 
         self.add_observer(add_context::<C>)
             .add_observer(remove_context::<C>);
@@ -45,17 +64,92 @@ impl InputContextAppExt for App {
     }
 }
 
-/// IDs of registered [`Actions`].
+/// Tracks registered input contexts for each [`InputContext::Schedule`].
 ///
-/// Used later to configure [`FilteredEntityMut`].
-/// Exists only at plugins initialization stage.
+/// In Bevy, it’s impossible to know which schedule is used inside a system,
+/// so we genericize update systems over schedules.
+///
+/// This resource stores registered contexts per-schedule in a type-erased way
+/// to perform the setup after all registrations in [`App::finish`].
+///
+/// Exists only during the plugin initialization.
 #[derive(Resource, Default, Deref, DerefMut)]
-pub(crate) struct ActionsRegistry(Vec<ComponentId>);
+pub(crate) struct ContextRegistry(Vec<ScheduleContexts>);
+
+pub(crate) struct ScheduleContexts {
+    /// Schedule ID for which all actions were registered.
+    schedule_id: TypeId,
+
+    /// IDs of [`Actions`]
+    action_ids: Vec<ComponentId>,
+
+    /// Configures the app for this schedule.
+    setup: fn(&Self, &mut App),
+}
+
+impl ScheduleContexts {
+    /// Creates a new instance for schedule `S`.
+    ///
+    /// [`Self::setup`] will configure the app for `S`.
+    fn new<S: ScheduleLabel + Default>() -> Self {
+        Self {
+            schedule_id: TypeId::of::<S>(),
+            action_ids: Default::default(),
+            // Since the type is not present in the function signature, we can store
+            // functions for specific type without making the struct generic.
+            setup: Self::setup_typed::<S>,
+        }
+    }
+
+    /// Calls [`Self::setup_typed`] for `S` that was associated in [`Self::new`].
+    pub(crate) fn setup(&self, app: &mut App) {
+        (self.setup)(self, app);
+    }
+
+    /// Configures the app for all contexts registered for schedule `C`.
+    pub(crate) fn setup_typed<S: ScheduleLabel + Default>(&self, app: &mut App) {
+        let update = (
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            QueryParamBuilder::new(|builder| {
+                builder.optional(|builder| {
+                    for &id in &self.action_ids {
+                        builder.mut_id(id);
+                    }
+                });
+            }),
+        )
+            .build_state(app.world_mut())
+            .build_system(update::<S>);
+
+        let rebuild = (
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            QueryParamBuilder::new(|builder| {
+                builder.optional(|builder| {
+                    for &id in &self.action_ids {
+                        builder.mut_id(id);
+                    }
+                });
+            }),
+        )
+            .build_state(app.world_mut())
+            .build_any_system(rebuild::<S>);
+
+        app.init_resource::<ActionInstances<S>>()
+            .add_observer(rebuild)
+            .add_systems(S::default(), update.in_set(EnhancedInputSystem));
+    }
+}
 
 fn add_context<C: InputContext>(
     trigger: Trigger<OnInsert, Actions<C>>,
     mut commands: Commands,
-    mut instances: ResMut<ActionInstances>,
+    mut instances: ResMut<ActionInstances<C::Schedule>>,
 ) {
     instances.add::<C>(&mut commands, trigger.target());
 }
@@ -64,7 +158,7 @@ fn remove_context<C: InputContext>(
     trigger: Trigger<OnReplace, Actions<C>>,
     mut commands: Commands,
     mut reset_input: ResMut<ResetInput>,
-    mut instances: ResMut<ActionInstances>,
+    mut instances: ResMut<ActionInstances<C::Schedule>>,
     time: Res<Time<Virtual>>,
     mut actions: Query<&mut Actions<C>>,
 ) {
@@ -77,13 +171,39 @@ fn remove_context<C: InputContext>(
     );
 }
 
-/// Stores instantiated [`Actions`].
+fn update<S: ScheduleLabel>(
+    mut commands: Commands,
+    mut reader: InputReader,
+    time: Res<Time<Virtual>>, // We explicitly use `Virtual` to have access to `relative_speed`.
+    mut instances: ResMut<ActionInstances<S>>,
+    mut actions: Query<FilteredEntityMut>,
+) {
+    reader.update_state();
+    instances.update(&mut commands, &mut reader, &time, &mut actions);
+}
+
+fn rebuild<S: ScheduleLabel>(
+    _trigger: Trigger<RebuildBindings>,
+    mut commands: Commands,
+    mut reset_input: ResMut<ResetInput>,
+    mut instances: ResMut<ActionInstances<S>>,
+    time: Res<Time<Virtual>>,
+    mut actions: Query<FilteredEntityMut>,
+) {
+    instances.rebuild(&mut commands, &mut reset_input, &time, &mut actions);
+}
+
+/// Stores instantiated [`Actions`] for a schedule `S`.
 ///
 /// Used to iterate over them in a defined order and operate in a type-erased manner.
 #[derive(Resource, Default, Deref)]
-pub(crate) struct ActionInstances(Vec<ActionsInstance>);
+pub(crate) struct ActionInstances<S: ScheduleLabel> {
+    #[deref]
+    instances: Vec<ActionsInstance>,
+    marker: PhantomData<S>,
+}
 
-impl ActionInstances {
+impl<S: ScheduleLabel> ActionInstances<S> {
     pub(crate) fn update(
         &mut self,
         commands: &mut Commands,
@@ -91,7 +211,7 @@ impl ActionInstances {
         time: &Time<Virtual>,
         actions: &mut Query<FilteredEntityMut>,
     ) {
-        for instance in &mut self.0 {
+        for instance in &mut self.instances {
             instance.update(commands, reader, time, actions);
         }
     }
@@ -103,7 +223,7 @@ impl ActionInstances {
         time: &Time<Virtual>,
         actions: &mut Query<FilteredEntityMut>,
     ) {
-        for instance in &mut self.0 {
+        for instance in &mut self.instances {
             instance.rebuild(commands, reset_input, time, actions);
         }
     }
@@ -125,9 +245,10 @@ impl ActionInstances {
                     .skip(index + 1)
                     .position(|inst| inst.priority != C::PRIORITY)
                     .unwrap_or_default();
-                self.0.insert(index + last_priority_index + 1, instance);
+                self.instances
+                    .insert(index + last_priority_index + 1, instance);
             }
-            Err(index) => self.0.insert(index, instance),
+            Err(index) => self.instances.insert(index, instance),
         };
     }
 
@@ -149,7 +270,7 @@ impl ActionInstances {
             .iter()
             .position(|inst| inst.entity == entity && inst.type_id == TypeId::of::<C>())
             .expect("input entry should be created before removal");
-        self.0.remove(index);
+        self.instances.remove(index);
 
         let mut instance = instances.get_mut(entity).unwrap();
         instance.reset(commands, reset_input, time, entity);
@@ -173,8 +294,6 @@ impl ActionsInstance {
             entity,
             priority: C::PRIORITY,
             type_id: TypeId::of::<C>(),
-            // Since the type is not present in the signature, we can store
-            // functions for specific type without making the struct generic.
             update: Self::update_typed::<C>,
             rebuild: Self::rebuild_typed::<C>,
         }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -4,7 +4,9 @@ use core::{
     marker::PhantomData,
 };
 
-use bevy::{platform_support::collections::hash_map::Entry, prelude::*};
+use bevy::{
+    ecs::schedule::ScheduleLabel, platform_support::collections::hash_map::Entry, prelude::*,
+};
 
 use crate::{
     action_binding::ActionBinding,
@@ -174,18 +176,30 @@ impl<C: InputContext> Default for Actions<C> {
 /// struct Player;
 /// ```
 ///
-/// Optionally you can pass `priority`:
+/// Optionally you can pass `priority` and/or `schedule`:
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
 /// #[derive(InputContext)]
-/// #[input_context(priority = 1)]
+/// #[input_context(priority = 1, schedule = FixedPreUpdate)]
 /// struct Player;
 /// ```
 ///
 /// All parameters match corresponding data in the trait.
 pub trait InputContext: Send + Sync + 'static {
+    /// Schedule in which the context will be evaluated.
+    ///
+    /// Associated type defaults are not stabilized in Rust yet,
+    /// but the macro uses [`PreUpdate`] by default.
+    ///
+    /// Set this to [`FixedPreUpdate`] if game logic relies on actions from this context
+    /// in [`FixedUpdate`]. For example, if [`FixedMain`](bevy::app::FixedMain) runs twice
+    /// in a single frame and an action triggers, you will get [`Started`](crate::events::Started)
+    /// and [`Fired`](crate::events::Fired) on the first run and only [`Fired`](crate::events::Fired)
+    /// on the second run.
+    type Schedule: ScheduleLabel + Default;
+
     /// Determines the evaluation order of [`Actions<Self>`].
     ///
     /// Used to control how contexts are layered since some [`InputAction`]s may consume inputs.

--- a/tests/fixed_timestep.rs
+++ b/tests/fixed_timestep.rs
@@ -1,0 +1,95 @@
+use bevy::{input::InputPlugin, prelude::*, time::TimeUpdateStrategy};
+use bevy_enhanced_input::prelude::*;
+
+#[test]
+fn once_in_two_frames() {
+    let time_step = Time::<Fixed>::default().timestep() / 2;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+        .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
+        .add_input_context::<Dummy>()
+        .add_observer(binding)
+        .finish();
+
+    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+
+    app.world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(DummyAction::KEY);
+
+    for frame in 0..2 {
+        app.update();
+
+        let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+        assert!(
+            actions.action::<DummyAction>().events().is_empty(),
+            "shouldn't fire on frame {frame}"
+        );
+    }
+
+    for frame in 2..4 {
+        app.update();
+
+        let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+        let action = actions.action::<DummyAction>();
+        assert_eq!(
+            action.events(),
+            ActionEvents::STARTED | ActionEvents::FIRED,
+            "should maintain start-firing on frame {frame}"
+        );
+    }
+}
+
+#[test]
+fn twice_in_one_frame() {
+    let time_step = Time::<Fixed>::default().timestep() * 2;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+        .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
+        .add_input_context::<Dummy>()
+        .add_observer(binding)
+        .finish();
+
+    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+
+    app.world_mut()
+        .resource_mut::<ButtonInput<KeyCode>>()
+        .press(DummyAction::KEY);
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    assert!(
+        actions.action::<DummyAction>().events().is_empty(),
+        "`FixedMain` should never run on the first frame"
+    );
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let action = actions.action::<DummyAction>();
+    assert_eq!(
+        action.events(),
+        ActionEvents::FIRED,
+        "should run twice, so it shouldn't be started on the second run"
+    );
+}
+
+fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+    let mut actions = actions.get_mut(trigger.target()).unwrap();
+    actions.bind::<DummyAction>().to(DummyAction::KEY);
+}
+
+#[derive(InputContext)]
+#[input_context(schedule = FixedPreUpdate)]
+struct Dummy;
+
+#[derive(Debug, InputAction)]
+#[input_action(output = bool)]
+struct DummyAction;
+
+impl DummyAction {
+    const KEY: KeyCode = KeyCode::KeyA;
+}


### PR DESCRIPTION
Configurable via associated type or in a macro:

```rust
#[derive(InputContext)]
#[input_context(priority = 1, schedule = FixedPreUpdate)]
struct Player;
```

In Bevy, it’s impossible to know which schedule is used inside a system, so I genericized update systems over schedules. I stored registered contexts per-schedule in a type-erased way and perform the setup after all registrations in `App::finish`.

Targets bevy-0.16-dev since I need `Default` impls from rc.4.
