### PR TITLE
Downgrade `ron` to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bevy = { version = "0.15", default-features = false, features = [
   "bevy_window",
   "x11",
 ] }
-ron = "0.9"
+ron = "0.8"
 
 [lints.clippy]
 type_complexity = "allow"


### PR DESCRIPTION
It's the Bevy currently uses.
We need it only as dev-dependency, but it's better to avoid compiling it twice.