### PR TITLE
Log read value

### DIFF
--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -314,6 +314,7 @@ impl ActionBinding {
             }
 
             let mut current_tracker = TriggerTracker::new(value);
+            trace!("reading value `{value:?}`");
             current_tracker.apply_modifiers(action_map, time, &mut binding.modifiers);
             current_tracker.apply_conditions(action_map, time, &mut binding.conditions);
 


### PR DESCRIPTION
Right now we log modifier changes. But if there are no modifiers, the original value won't be logged. Let's log it.