### PR TITLE
Rename `Press` to `Down` and `JustPress` to `Press`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `Press` into `Down`.
+- Rename `JustPress` into `Press`.
+
 ## [0.11.0] - 2025-04-24
 
 ### Added

--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -37,11 +37,11 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
     actions
         .bind::<PressAction>()
         .to(PressAction::KEY)
-        .with_conditions(Press::default());
+        .with_conditions(Down::default());
     actions
         .bind::<JustPressAction>()
         .to(JustPressAction::KEY)
-        .with_conditions(JustPress::default());
+        .with_conditions(Press::default());
     actions
         .bind::<HoldAction>()
         .to(HoldAction::KEY)

--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -154,7 +154,7 @@ impl ActionBinding {
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
-    ///     .with_conditions((Release::default(), JustPress::default()));
+    ///     .with_conditions((Release::default(), Press::default()));
     /// # #[derive(InputContext)]
     /// # struct Dummy;
     /// # #[derive(Debug, InputAction)]

--- a/src/input_binding.rs
+++ b/src/input_binding.rs
@@ -113,7 +113,7 @@ pub trait BindingBuilder {
     /// # use bevy_enhanced_input::prelude::*;
     /// # let mut actions = Actions::<Dummy>::default();
     /// actions.bind::<Jump>()
-    ///     .to(KeyCode::Space.with_conditions((Release::default(), JustPress::default())));
+    ///     .to(KeyCode::Space.with_conditions((Release::default(), Press::default())));
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -51,7 +51,7 @@ pub trait InputCondition: Sync + Send + Debug + 'static {
 /// Determines how a condition contributes to the final [`ActionState`].
 ///
 /// If no conditions are provided, the state will be set to [`ActionState::Fired`]
-/// on any non-zero value, functioning similarly to a [`Press`](press::Press) condition
+/// on any non-zero value, functioning similarly to a [`Down`](press::Down) condition
 /// with a zero actuation threshold.
 ///
 /// For details about how actions are combined, see [`Actions`](crate::actions::Actions).

--- a/src/input_condition/just_press.rs
+++ b/src/input_condition/just_press.rs
@@ -6,17 +6,17 @@ use crate::{
     action_value::ActionValue,
 };
 
-/// Like [`super::press::Press`] but returns [`ActionState::Fired`] only once until the next actuation.
+/// Like [`super::press::Down`] but returns [`ActionState::Fired`] only once until the next actuation.
 ///
 /// Holding the input will not cause further triggers.
 #[derive(Clone, Copy, Debug)]
-pub struct JustPress {
+pub struct Press {
     /// Trigger threshold.
     pub actuation: f32,
     actuated: bool,
 }
 
-impl JustPress {
+impl Press {
     #[must_use]
     pub fn new(actuation: f32) -> Self {
         Self {
@@ -26,13 +26,13 @@ impl JustPress {
     }
 }
 
-impl Default for JustPress {
+impl Default for Press {
     fn default() -> Self {
         Self::new(DEFAULT_ACTUATION)
     }
 }
 
-impl InputCondition for JustPress {
+impl InputCondition for Press {
     fn evaluate(
         &mut self,
         _action_map: &ActionMap,
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn press() {
-        let mut condition = JustPress::default();
+        let mut condition = Press::default();
         let action_map = ActionMap::default();
         let time = Time::default();
 

--- a/src/input_condition/press.rs
+++ b/src/input_condition/press.rs
@@ -8,25 +8,25 @@ use crate::{
 
 /// Returns [`ActionState::Fired`] when the input exceeds the actuation threshold.
 #[derive(Clone, Copy, Debug)]
-pub struct Press {
+pub struct Down {
     /// Trigger threshold.
     pub actuation: f32,
 }
 
-impl Press {
+impl Down {
     #[must_use]
     pub fn new(actuation: f32) -> Self {
         Self { actuation }
     }
 }
 
-impl Default for Press {
+impl Default for Down {
     fn default() -> Self {
         Self::new(DEFAULT_ACTUATION)
     }
 }
 
-impl InputCondition for Press {
+impl InputCondition for Down {
     fn evaluate(
         &mut self,
         _action_map: &ActionMap,
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn down() {
-        let mut condition = Press::new(1.0);
+        let mut condition = Down::new(1.0);
         let action_map = ActionMap::default();
         let time = Time::default();
 

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -257,7 +257,7 @@ fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Pl
         .with_conditions(Release::default());
     actions
         .bind::<Explicit>()
-        .with_conditions(Press::default())
+        .with_conditions(Down::default())
         .to(Explicit::KEY);
     actions
         .bind::<Implicit>()

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -258,7 +258,7 @@ fn both_levels() {
 fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
 
-    let down = Press::default();
+    let down = Down::default();
     let release = Release::default();
     let chord = Chord::<ChordMember>::default();
     let block_by = BlockBy::<Blocker>::default();


### PR DESCRIPTION
Reverts to Unreal Engine's original naming convention.
The names were initially changed to avoid conflicts with `bevy_picking`, but we can now reclaim them since `bevy_picking` has migrated from `Down` to `Pressed`.