### PR TITLE
Remove uses of the word "Dummy"

### DIFF
--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -22,17 +22,17 @@ struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_input_context::<Dummy>()
+        app.add_input_context::<Test>()
             .add_observer(binding)
             .add_systems(Startup, spawn);
     }
 }
 
 fn spawn(mut commands: Commands) {
-    commands.spawn(Actions::<Dummy>::default());
+    commands.spawn(Actions::<Test>::default());
 }
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
         .bind::<PressAction>()
@@ -82,7 +82,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
 }
 
 #[derive(InputContext)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool)]

--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -88,12 +88,12 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_modifiers(Scale::splat(2.0));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
     /// # struct Jump;
@@ -104,12 +104,12 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_modifiers((Scale::splat(2.0), Negate::all()));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
     /// # struct Jump;
@@ -135,12 +135,12 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_conditions(Release::default());
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
@@ -151,12 +151,12 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space)
     ///     .with_conditions((Release::default(), Press::default()));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
@@ -190,11 +190,11 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to((KeyCode::Space, GamepadButton::South));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
@@ -205,10 +205,10 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>().to(KeyCode::Space.with_mod_keys(ModKeys::CONTROL));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
@@ -219,11 +219,11 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>().to(KeyCode::Space.with_conditions(Release::default()));
     /// actions.bind::<Attack>().to(MouseButton::Left.with_modifiers(Scale::splat(10.0)));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
@@ -237,11 +237,11 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Zoom>().to(Input::mouse_wheel());
     /// actions.bind::<Move>().to(Input::mouse_motion());
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Zoom;
@@ -256,10 +256,10 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Move>().to(Cardinal::wasd_keys());
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = Vec2)]
     /// # struct Move;
@@ -270,7 +270,7 @@ impl ActionBinding {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// # let mut settings = KeyboardSettings::default();
     /// actions.bind::<Inspect>().to(&settings.inspect);
     ///
@@ -279,7 +279,7 @@ impl ActionBinding {
     ///     inspect: Vec<KeyCode>,
     /// }
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = Vec2)]
     /// # struct Inspect;

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -214,19 +214,19 @@ mod tests {
 
     #[test]
     fn bind() {
-        let mut actions = Actions::<Dummy>::default();
-        actions.bind::<DummyAction>().to(KeyCode::KeyA);
-        actions.bind::<DummyAction>().to(KeyCode::KeyB);
+        let mut actions = Actions::<Test>::default();
+        actions.bind::<TestAction>().to(KeyCode::KeyA);
+        actions.bind::<TestAction>().to(KeyCode::KeyB);
         assert_eq!(actions.bindings.len(), 1);
 
-        let binding = actions.binding::<DummyAction>();
+        let binding = actions.binding::<TestAction>();
         assert_eq!(binding.inputs().len(), 2);
     }
 
     #[derive(Debug, InputAction)]
     #[input_action(output = bool)]
-    struct DummyAction;
+    struct TestAction;
 
     #[derive(InputContext)]
-    struct Dummy;
+    struct Test;
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -250,34 +250,34 @@ mod tests {
 
     fn transition(initial_state: ActionState, target_state: ActionState) -> ActionEvents {
         let time = Time::<Virtual>::default();
-        let mut action = Action::new::<DummyAction>();
+        let mut action = Action::new::<TestAction>();
         action.update(&time, initial_state, true);
         action.update(&time, target_state, true);
 
         let mut world = World::new();
         world.init_resource::<TriggeredEvents>();
         world.add_observer(
-            |_trigger: Trigger<Fired<DummyAction>>, mut events: ResMut<TriggeredEvents>| {
+            |_trigger: Trigger<Fired<TestAction>>, mut events: ResMut<TriggeredEvents>| {
                 events.insert(ActionEvents::FIRED);
             },
         );
         world.add_observer(
-            |_trigger: Trigger<Started<DummyAction>>, mut events: ResMut<TriggeredEvents>| {
+            |_trigger: Trigger<Started<TestAction>>, mut events: ResMut<TriggeredEvents>| {
                 events.insert(ActionEvents::STARTED);
             },
         );
         world.add_observer(
-            |_trigger: Trigger<Ongoing<DummyAction>>, mut events: ResMut<TriggeredEvents>| {
+            |_trigger: Trigger<Ongoing<TestAction>>, mut events: ResMut<TriggeredEvents>| {
                 events.insert(ActionEvents::ONGOING);
             },
         );
         world.add_observer(
-            |_trigger: Trigger<Completed<DummyAction>>, mut events: ResMut<TriggeredEvents>| {
+            |_trigger: Trigger<Completed<TestAction>>, mut events: ResMut<TriggeredEvents>| {
                 events.insert(ActionEvents::COMPLETED);
             },
         );
         world.add_observer(
-            |_trigger: Trigger<Canceled<DummyAction>>, mut events: ResMut<TriggeredEvents>| {
+            |_trigger: Trigger<Canceled<TestAction>>, mut events: ResMut<TriggeredEvents>| {
                 events.insert(ActionEvents::CANCELED);
             },
         );
@@ -293,5 +293,5 @@ mod tests {
 
     #[derive(Debug, InputAction)]
     #[input_action(output = bool)]
-    struct DummyAction;
+    struct TestAction;
 }

--- a/src/input_binding.rs
+++ b/src/input_binding.rs
@@ -55,11 +55,11 @@ pub trait BindingBuilder {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_modifiers(Scale::splat(2.0)));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
     /// # struct Jump;
@@ -70,11 +70,11 @@ pub trait BindingBuilder {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_modifiers((Scale::splat(2.0), Negate::all())));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = f32)]
     /// # struct Jump;
@@ -96,11 +96,11 @@ pub trait BindingBuilder {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_conditions(Release::default()));
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
@@ -111,14 +111,14 @@ pub trait BindingBuilder {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Jump>()
     ///     .to(KeyCode::Space.with_conditions((Release::default(), Press::default())));
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Jump;
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// ```
     #[must_use]
     fn with_conditions(self, conditions: impl IntoConditions) -> InputBinding;
@@ -163,7 +163,7 @@ pub trait IntoBindings {
     /// ```
     /// # use bevy::prelude::*;
     /// # use bevy_enhanced_input::prelude::*;
-    /// # let mut actions = Actions::<Dummy>::default();
+    /// # let mut actions = Actions::<Player>::default();
     /// actions.bind::<Move>()
     ///     .to((
     ///         Input::mouse_motion(),
@@ -171,7 +171,7 @@ pub trait IntoBindings {
     ///     ))
     ///     .with_modifiers(DeadZone::default()); // Modifiers like `DeadZone` need to be applied at the action level!
     /// # #[derive(InputContext)]
-    /// # struct Dummy;
+    /// # struct Player;
     /// # #[derive(Debug, InputAction)]
     /// # #[input_action(output = bool)]
     /// # struct Move;

--- a/src/input_condition/block_by.rs
+++ b/src/input_condition/block_by.rs
@@ -92,12 +92,12 @@ mod tests {
 
     #[test]
     fn block() {
-        let mut condition = BlockBy::<DummyAction>::default();
-        let mut action = Action::new::<DummyAction>();
+        let mut condition = BlockBy::<TestAction>::default();
+        let mut action = Action::new::<TestAction>();
         let time = Time::default();
         action.update(&time, ActionState::Fired, true);
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<DummyAction>(action);
+        action_map.insert_action::<TestAction>(action);
 
         assert_eq!(
             condition.evaluate(&action_map, &time, true.into()),
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn missing_action() {
-        let mut condition = BlockBy::<DummyAction>::default();
+        let mut condition = BlockBy::<TestAction>::default();
         let action_map = ActionMap::default();
         let time = Time::default();
 
@@ -119,5 +119,5 @@ mod tests {
 
     #[derive(Debug, InputAction)]
     #[input_action(output = bool)]
-    struct DummyAction;
+    struct TestAction;
 }

--- a/src/input_condition/chord.rs
+++ b/src/input_condition/chord.rs
@@ -69,12 +69,12 @@ mod tests {
 
     #[test]
     fn chord() {
-        let mut condition = Chord::<DummyAction>::default();
-        let mut action = Action::new::<DummyAction>();
+        let mut condition = Chord::<TestAction>::default();
+        let mut action = Action::new::<TestAction>();
         let time = Time::default();
         action.update(&time, ActionState::Fired, true);
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<DummyAction>(action);
+        action_map.insert_action::<TestAction>(action);
 
         assert_eq!(
             condition.evaluate(&action_map, &time, true.into()),
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn missing_action() {
-        let mut condition = Chord::<DummyAction>::default();
+        let mut condition = Chord::<TestAction>::default();
         let action_map = ActionMap::default();
         let time = Time::default();
 
@@ -96,5 +96,5 @@ mod tests {
 
     #[derive(Debug, InputAction)]
     #[input_action(output = bool)]
-    struct DummyAction;
+    struct TestAction;
 }

--- a/src/input_modifier/accumulate_by.rs
+++ b/src/input_modifier/accumulate_by.rs
@@ -66,12 +66,12 @@ mod tests {
 
     #[test]
     fn accumulation_active() {
-        let mut modifier = AccumulateBy::<DummyAction>::default();
-        let mut action = Action::new::<DummyAction>();
+        let mut modifier = AccumulateBy::<TestAction>::default();
+        let mut action = Action::new::<TestAction>();
         let time = Time::default();
         action.update(&time, ActionState::Fired, true);
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<DummyAction>(action);
+        action_map.insert_action::<TestAction>(action);
 
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 2.0.into());
@@ -79,11 +79,11 @@ mod tests {
 
     #[test]
     fn accumulation_inactive() {
-        let mut modifier = AccumulateBy::<DummyAction>::default();
-        let action = Action::new::<DummyAction>();
+        let mut modifier = AccumulateBy::<TestAction>::default();
+        let action = Action::new::<TestAction>();
         let time = Time::default();
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<DummyAction>(action);
+        action_map.insert_action::<TestAction>(action);
 
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn missing_action() {
-        let mut modifier = AccumulateBy::<DummyAction>::default();
+        let mut modifier = AccumulateBy::<TestAction>::default();
         let action_map = ActionMap::default();
         let time = Time::default();
 
@@ -101,5 +101,5 @@ mod tests {
 
     #[derive(Debug, InputAction)]
     #[input_action(output = bool)]
-    struct DummyAction;
+    struct TestAction;
 }

--- a/tests/accumulation.rs
+++ b/tests/accumulation.rs
@@ -5,11 +5,11 @@ use bevy_enhanced_input::prelude::*;
 fn max_abs() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -19,7 +19,7 @@ fn max_abs() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<MaxAbs>().value(), Vec2::Y.into());
 }
 
@@ -27,11 +27,11 @@ fn max_abs() {
 fn cumulative() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -41,7 +41,7 @@ fn cumulative() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(
         actions.action::<Cumulative>().value(),
         Vec2::ZERO.into(),
@@ -49,14 +49,14 @@ fn cumulative() {
     );
 }
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<MaxAbs>().to(Cardinal::wasd_keys());
     actions.bind::<Cumulative>().to(Cardinal::arrow_keys());
 }
 
 #[derive(InputContext)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = Vec2, accumulation = MaxAbs)]

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -17,7 +17,7 @@ fn any() {
     app.update();
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.analog_mut().set(DummyAction::BUTTON, 1.0);
+    gamepad1.analog_mut().set(TestAction::BUTTON, 1.0);
 
     app.update();
 
@@ -25,13 +25,13 @@ fn any() {
         .world()
         .get::<Actions<AnyGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.analog_mut().set(DummyAction::BUTTON, 0.0);
+    gamepad1.analog_mut().set(TestAction::BUTTON, 0.0);
 
     let mut gamepad2 = app.world_mut().get_mut::<Gamepad>(gamepad_entity2).unwrap();
-    gamepad2.analog_mut().set(DummyAction::BUTTON, 1.0);
+    gamepad2.analog_mut().set(TestAction::BUTTON, 1.0);
 
     app.update();
 
@@ -39,7 +39,7 @@ fn any() {
         .world()
         .get::<Actions<AnyGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn by_id() {
     app.update();
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.analog_mut().set(DummyAction::BUTTON, 1.0);
+    gamepad1.analog_mut().set(TestAction::BUTTON, 1.0);
 
     app.update();
 
@@ -72,13 +72,13 @@ fn by_id() {
         .world()
         .get::<Actions<SingleGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
-    gamepad1.analog_mut().set(DummyAction::BUTTON, 0.0);
+    gamepad1.analog_mut().set(TestAction::BUTTON, 0.0);
 
     let mut gamepad2 = app.world_mut().get_mut::<Gamepad>(gamepad_entity2).unwrap();
-    gamepad2.analog_mut().set(DummyAction::BUTTON, 1.0);
+    gamepad2.analog_mut().set(TestAction::BUTTON, 1.0);
 
     app.update();
 
@@ -86,7 +86,7 @@ fn by_id() {
         .world()
         .get::<Actions<SingleGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<DummyAction>().state(), ActionState::None);
+    assert_eq!(actions.action::<TestAction>().state(), ActionState::None);
 }
 
 fn any_gamepad_binding(
@@ -94,7 +94,7 @@ fn any_gamepad_binding(
     mut actions: Query<&mut Actions<AnyGamepad>>,
 ) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
-    actions.bind::<DummyAction>().to(DummyAction::BUTTON);
+    actions.bind::<TestAction>().to(TestAction::BUTTON);
 }
 
 fn single_gamepad_binding(
@@ -103,7 +103,7 @@ fn single_gamepad_binding(
 ) {
     let (mut actions, gamepad) = actions.get_mut(trigger.target()).unwrap();
     actions.set_gamepad(**gamepad);
-    actions.bind::<DummyAction>().to(DummyAction::BUTTON);
+    actions.bind::<TestAction>().to(TestAction::BUTTON);
 }
 
 #[derive(InputContext)]
@@ -114,8 +114,8 @@ struct SingleGamepad(Entity);
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool)]
-struct DummyAction;
+struct TestAction;
 
-impl DummyAction {
+impl TestAction {
     const BUTTON: GamepadButton = GamepadButton::South;
 }

--- a/tests/dim.rs
+++ b/tests/dim.rs
@@ -5,11 +5,11 @@ use bevy_enhanced_input::prelude::*;
 fn bool() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -19,7 +19,7 @@ fn bool() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Bool>().value(), true.into());
 
     app.world_mut()
@@ -28,7 +28,7 @@ fn bool() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Bool>().value(), false.into());
 }
 
@@ -36,11 +36,11 @@ fn bool() {
 fn axis1d() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -50,7 +50,7 @@ fn axis1d() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Axis1D>().value(), 1.0.into());
 
     app.world_mut()
@@ -59,7 +59,7 @@ fn axis1d() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Axis1D>().value(), 0.0.into());
 }
 
@@ -67,11 +67,11 @@ fn axis1d() {
 fn axis2d() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -81,7 +81,7 @@ fn axis2d() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Axis2D>().value(), (1.0, 0.0).into());
 
     app.world_mut()
@@ -90,7 +90,7 @@ fn axis2d() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Axis2D>().value(), Vec2::ZERO.into());
 }
 
@@ -98,11 +98,11 @@ fn axis2d() {
 fn axis3d() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -112,7 +112,7 @@ fn axis3d() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Axis3D>().value(), (1.0, 0.0, 0.0).into());
 
     app.world_mut()
@@ -121,11 +121,11 @@ fn axis3d() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.action::<Axis3D>().value(), Vec3::ZERO.into());
 }
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Bool>().to(Bool::KEY);
     actions.bind::<Axis1D>().to(Axis1D::KEY);
@@ -134,7 +134,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
 }
 
 #[derive(InputContext)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool)]

--- a/tests/fixed_timestep.rs
+++ b/tests/fixed_timestep.rs
@@ -8,22 +8,22 @@ fn once_in_two_frames() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     for frame in 0..2 {
         app.update();
 
-        let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+        let actions = app.world().get::<Actions<Test>>(entity).unwrap();
         assert!(
-            actions.action::<DummyAction>().events().is_empty(),
+            actions.action::<TestAction>().events().is_empty(),
             "shouldn't fire on frame {frame}"
         );
     }
@@ -31,8 +31,8 @@ fn once_in_two_frames() {
     for frame in 2..4 {
         app.update();
 
-        let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
-        let action = actions.action::<DummyAction>();
+        let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+        let action = actions.action::<TestAction>();
         assert_eq!(
             action.events(),
             ActionEvents::STARTED | ActionEvents::FIRED,
@@ -48,28 +48,28 @@ fn twice_in_one_frame() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert!(
-        actions.action::<DummyAction>().events().is_empty(),
+        actions.action::<TestAction>().events().is_empty(),
         "`FixedMain` should never run on the first frame"
     );
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
-    let action = actions.action::<DummyAction>();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.action::<TestAction>();
     assert_eq!(
         action.events(),
         ActionEvents::FIRED,
@@ -77,19 +77,19 @@ fn twice_in_one_frame() {
     );
 }
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
-    actions.bind::<DummyAction>().to(DummyAction::KEY);
+    actions.bind::<TestAction>().to(TestAction::KEY);
 }
 
 #[derive(InputContext)]
 #[input_context(schedule = FixedPreUpdate)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool)]
-struct DummyAction;
+struct TestAction;
 
-impl DummyAction {
+impl TestAction {
     const KEY: KeyCode = KeyCode::KeyA;
 }

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -5,24 +5,22 @@ use bevy_enhanced_input::prelude::*;
 fn removal() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
-    app.world_mut()
-        .entity_mut(entity)
-        .remove::<Actions<Dummy>>();
+    app.world_mut().entity_mut(entity).remove::<Actions<Test>>();
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.world_mut()
-        .add_observer(|_: Trigger<Fired<DummyAction>>| {
+        .add_observer(|_: Trigger<Fired<TestAction>>| {
             panic!("action shouldn't trigger");
         });
 
@@ -33,68 +31,68 @@ fn removal() {
 fn rebuild() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
     app.world_mut()
         .entity_mut(entity)
-        .insert(Actions::<Dummy>::default());
+        .insert(Actions::<Test>::default());
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
-    assert!(actions.get_action::<DummyAction>().is_some());
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    assert!(actions.get_action::<TestAction>().is_some());
 }
 
 #[test]
 fn rebuild_all() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
-    assert_eq!(actions.action::<DummyAction>().state(), ActionState::Fired);
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
 
     app.world_mut().trigger(RebuildBindings);
     app.world_mut().flush();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(
-        actions.action::<DummyAction>().state(),
+        actions.action::<TestAction>().state(),
         ActionState::None,
         "state should reset on rebuild"
     );
 }
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
-    actions.bind::<DummyAction>().to(DummyAction::KEY);
+    actions.bind::<TestAction>().to(TestAction::KEY);
 }
 
 #[derive(InputContext)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool)]
-struct DummyAction;
+struct TestAction;
 
-impl DummyAction {
+impl TestAction {
     const KEY: KeyCode = KeyCode::KeyA;
 }

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -5,11 +5,11 @@ use bevy_enhanced_input::prelude::*;
 fn keys() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -31,9 +31,9 @@ fn keys() {
 
         app.update();
 
-        let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+        let actions = app.world().get::<Actions<Test>>(entity).unwrap();
         assert_eq!(
-            actions.action::<DummyAction>().value(),
+            actions.action::<TestAction>().value(),
             dir.into(),
             "`{key:?}` should result in `{dir}`"
         );
@@ -50,12 +50,12 @@ fn keys() {
 fn dpad() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
     let gamepad_entity = app.world_mut().spawn(Gamepad::default()).id();
-    let ctx_entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let ctx_entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -70,9 +70,9 @@ fn dpad() {
 
         app.update();
 
-        let actions = app.world().get::<Actions<Dummy>>(ctx_entity).unwrap();
+        let actions = app.world().get::<Actions<Test>>(ctx_entity).unwrap();
         assert_eq!(
-            actions.action::<DummyAction>().value(),
+            actions.action::<TestAction>().value(),
             dir.into(),
             "`{button:?}` should result in `{dir}`"
         );
@@ -88,12 +88,12 @@ fn dpad() {
 fn sticks() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
     let gamepad_entity = app.world_mut().spawn(Gamepad::default()).id();
-    let ctx_entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let ctx_entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -109,9 +109,9 @@ fn sticks() {
 
             app.update();
 
-            let actions = app.world().get::<Actions<Dummy>>(ctx_entity).unwrap();
+            let actions = app.world().get::<Actions<Test>>(ctx_entity).unwrap();
             assert_eq!(
-                actions.action::<DummyAction>().value(),
+                actions.action::<TestAction>().value(),
                 dir.into(),
                 "`{axis:?}` should result in `{dir}`"
             );
@@ -129,9 +129,9 @@ const LEFT: Vec2 = Vec2::new(-1.0, 0.0);
 const DOWN: Vec2 = Vec2::new(0.0, -1.0);
 const RIGHT: Vec2 = Vec2::new(1.0, 0.0);
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
-    actions.bind::<DummyAction>().to((
+    actions.bind::<TestAction>().to((
         Cardinal::wasd_keys(),
         Cardinal::arrow_keys(),
         Cardinal::dpad_buttons(),
@@ -145,8 +145,8 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
 }
 
 #[derive(InputContext)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = Vec2, consume_input = true)]
-struct DummyAction;
+struct TestAction;

--- a/tests/require_reset.rs
+++ b/tests/require_reset.rs
@@ -20,15 +20,15 @@ fn layering() {
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.update();
 
     let first = app.world().get::<Actions<First>>(entity).unwrap();
-    assert_eq!(first.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(first.action::<TestAction>().state(), ActionState::Fired);
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
-    assert_eq!(second.action::<DummyAction>().state(), ActionState::None);
+    assert_eq!(second.action::<TestAction>().state(), ActionState::None);
 
     app.world_mut()
         .entity_mut(entity)
@@ -38,25 +38,25 @@ fn layering() {
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
     assert_eq!(
-        second.action::<DummyAction>().state(),
+        second.action::<TestAction>().state(),
         ActionState::None,
         "action should still be consumed even after removal"
     );
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .release(DummyAction::KEY);
+        .release(TestAction::KEY);
 
     app.update();
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.update();
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
-    assert_eq!(second.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(second.action::<TestAction>().state(), ActionState::Fired);
 }
 
 #[test]
@@ -75,12 +75,12 @@ fn switching() {
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.update();
 
     let actions = app.world().get::<Actions<First>>(entity).unwrap();
-    assert_eq!(actions.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
 
     app.world_mut()
         .entity_mut(entity)
@@ -91,35 +91,35 @@ fn switching() {
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
     assert_eq!(
-        second.action::<DummyAction>().state(),
+        second.action::<TestAction>().state(),
         ActionState::None,
         "action should still be consumed even after removal"
     );
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .release(DummyAction::KEY);
+        .release(TestAction::KEY);
 
     app.update();
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
-        .press(DummyAction::KEY);
+        .press(TestAction::KEY);
 
     app.update();
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
-    assert_eq!(second.action::<DummyAction>().state(), ActionState::Fired);
+    assert_eq!(second.action::<TestAction>().state(), ActionState::Fired);
 }
 
 fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
-    actions.bind::<DummyAction>().to(DummyAction::KEY);
+    actions.bind::<TestAction>().to(TestAction::KEY);
 }
 
 fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Actions<Second>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
-    actions.bind::<DummyAction>().to(DummyAction::KEY);
+    actions.bind::<TestAction>().to(TestAction::KEY);
 }
 
 #[derive(InputContext)]
@@ -131,8 +131,8 @@ struct Second;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool, require_reset = true)]
-struct DummyAction;
+struct TestAction;
 
-impl DummyAction {
+impl TestAction {
     const KEY: KeyCode = KeyCode::KeyA;
 }

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -7,11 +7,11 @@ use bevy_enhanced_input::prelude::*;
 fn input_level() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -21,7 +21,7 @@ fn input_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<InputLevel>();
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Ongoing);
@@ -32,7 +32,7 @@ fn input_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<InputLevel>();
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -43,7 +43,7 @@ fn input_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<InputLevel>();
     assert_eq!(action.value(), Vec2::NEG_Y.into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -54,7 +54,7 @@ fn input_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<InputLevel>();
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -65,7 +65,7 @@ fn input_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<InputLevel>();
     assert_eq!(action.value(), Vec2::ZERO.into());
     assert_eq!(
@@ -81,7 +81,7 @@ fn input_level() {
     panic_on_action_events::<InputLevel>(app.world_mut());
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<InputLevel>();
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -91,11 +91,11 @@ fn input_level() {
 fn action_level() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -105,7 +105,7 @@ fn action_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<ActionLevel>();
     assert_eq!(action.value(), (Vec2::NEG_Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Ongoing);
@@ -116,7 +116,7 @@ fn action_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<ActionLevel>();
     assert_eq!(action.value(), (Vec2::NEG_Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -127,7 +127,7 @@ fn action_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<ActionLevel>();
     assert_eq!(action.value(), (Vec2::NEG_Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -138,7 +138,7 @@ fn action_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<ActionLevel>();
     assert_eq!(action.value(), (Vec2::NEG_Y * 4.0).into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -149,7 +149,7 @@ fn action_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<ActionLevel>();
     assert_eq!(action.value(), (Vec2::NEG_Y * 4.0).into());
     assert_eq!(
@@ -165,7 +165,7 @@ fn action_level() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<ActionLevel>();
     assert_eq!(action.value(), (Vec2::NEG_Y * 4.0).into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -175,11 +175,11 @@ fn action_level() {
 fn both_levels() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Dummy>()
+        .add_input_context::<Test>()
         .add_observer(binding)
         .finish();
 
-    let entity = app.world_mut().spawn(Actions::<Dummy>::default()).id();
+    let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
 
     app.update();
 
@@ -189,7 +189,7 @@ fn both_levels() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<BothLevels>();
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Ongoing);
@@ -200,7 +200,7 @@ fn both_levels() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<BothLevels>();
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -211,7 +211,7 @@ fn both_levels() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<BothLevels>();
     assert_eq!(action.value(), Vec2::NEG_Y.into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -222,7 +222,7 @@ fn both_levels() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<BothLevels>();
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
@@ -233,7 +233,7 @@ fn both_levels() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<BothLevels>();
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(
@@ -249,13 +249,13 @@ fn both_levels() {
 
     app.update();
 
-    let actions = app.world().get::<Actions<Dummy>>(entity).unwrap();
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.action::<BothLevels>();
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
 }
 
-fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dummy>>) {
+fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
 
     let down = Down::default();
@@ -293,7 +293,7 @@ fn binding(trigger: Trigger<Binding<Dummy>>, mut actions: Query<&mut Actions<Dum
 }
 
 #[derive(InputContext)]
-struct Dummy;
+struct Test;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = Vec2)]


### PR DESCRIPTION
- Use `Player` in examples. More natural.
- Use `Test` in tests. Having a context called `Test` reads great.