### PR TITLE
Improve actions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+`Actions::state`, `Actions::value` and `Actions::events` helpers to obtain specific information for an action directly.
+
 ### Changed
 
 - Rename `Press` into `Down`.
 - Rename `JustPress` into `Press`.
+- Return `Result` from `Actions::bindings` to integrate with Bevy's unified error handling system.
+- Rename `Actions::action` into `Actions::get` and return `Result`.
+
+### Removed
+
+- `Actions::get_action`. Use `Actions::get`.
+- `Actions::get_binding`. Use `Actions::binding`.
 
 ## [0.11.0] - 2025-04-24
 
@@ -78,8 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rename `ContextInstance` into `InputContext`. `InputContext` is no longer a trait. Bindings now configured via observer on `Bindings<C>` (see docs on `InputContextAppExt::add_input_context` for details). Priority now set at runtime via `InputContext::set_priority`. 
-- Move all child modules from `input_context` under crate root (one level upper). 
+- Rename `ContextInstance` into `InputContext`. `InputContext` is no longer a trait. Bindings now configured via observer on `Bindings<C>` (see docs on `InputContextAppExt::add_input_context` for details). Priority now set at runtime via `InputContext::set_priority`.
+- Move all child modules from `input_context` under crate root (one level upper).
 - Capture gamepad buttons as `Axis1D` because triggers are also buttons and sometimes have analog value.
 - Rename `input_context` module into `registry` and `context_instance` into `input_context`.
 - Rename `ContextAppExt` into `InputContextAppExt`.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -254,7 +254,7 @@ mod tests {
 
         let binding = actions.binding::<TestAction>().unwrap();
         assert_eq!(binding.inputs().len(), 2);
-        assert!(actions.binding::<TestAction>().is_ok());
+        assert!(actions.get::<TestAction>().is_ok());
     }
 
     #[derive(Debug, InputAction)]

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -220,6 +220,13 @@ mod tests {
     use super::*;
 
     #[test]
+    fn empty() {
+        let actions = Actions::<Test>::default();
+        assert!(actions.binding::<TestAction>().is_err());
+        assert!(actions.get::<TestAction>().is_err());
+    }
+
+    #[test]
     fn bind() {
         let mut actions = Actions::<Test>::default();
         actions.bind::<TestAction>().to(KeyCode::KeyA);
@@ -228,6 +235,7 @@ mod tests {
 
         let binding = actions.binding::<TestAction>().unwrap();
         assert_eq!(binding.inputs().len(), 2);
+        assert!(actions.binding::<TestAction>().is_ok());
     }
 
     #[derive(Debug, InputAction)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,11 +287,12 @@ current value, state, or triggered events for this tick as [`ActionEvents`] bits
 # use bevy::prelude::*;
 # use bevy_enhanced_input::prelude::*;
 /// Apply movemenet when `Move` action considered fired.
-fn system(players: Single<(&Actions<OnFoot>, &mut Transform)>) {
+fn system(players: Single<(&Actions<OnFoot>, &mut Transform)>) -> Result<()> {
     let (actions, mut transform) = players.into_inner();
-    if actions.action::<Jump>().state() == ActionState::Fired {
+    if actions.state::<Jump>()? == ActionState::Fired {
         // Apply logic...
     }
+#   Ok(())
 }
 # #[derive(InputContext)]
 # struct OnFoot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ The event system is highly flexible. For example, you can use the [`Hold`] condi
 
 ### Pull-style
 
-You can also query for [`Actions`] within a system. Use [`Actions::action<A>`] to retrieve an [`Action`], from which you can obtain the
+You can also query for [`Actions`] within a system. Use [`Actions::get<A>`] to retrieve an [`Action`], from which you can obtain the
 current value, state, or triggered events for this tick as [`ActionEvents`] bitset.
 
 ```

--- a/tests/accumulation.rs
+++ b/tests/accumulation.rs
@@ -20,7 +20,7 @@ fn max_abs() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<MaxAbs>().value(), Vec2::Y.into());
+    assert_eq!(actions.value::<MaxAbs>().unwrap(), Vec2::Y.into());
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn cumulative() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(
-        actions.action::<Cumulative>().value(),
+        actions.value::<Cumulative>().unwrap(),
         Vec2::ZERO.into(),
         "up and down should cancel each other"
     );

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -4,7 +4,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn explicit() {
+fn explicit() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
@@ -16,7 +16,7 @@ fn explicit() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Explicit>();
+    let action = actions.get::<Explicit>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
@@ -27,7 +27,7 @@ fn explicit() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Explicit>();
+    let action = actions.get::<Explicit>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -38,13 +38,15 @@ fn explicit() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Explicit>();
+    let action = actions.get::<Explicit>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
+
+    Ok(())
 }
 
 #[test]
-fn implicit() {
+fn implicit() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
@@ -56,12 +58,12 @@ fn implicit() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Implicit>();
+    let action = actions.get::<Implicit>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
@@ -72,12 +74,12 @@ fn implicit() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Implicit>();
+    let action = actions.get::<Implicit>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
@@ -88,30 +90,32 @@ fn implicit() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::Fired);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Implicit>();
+    let action = actions.get::<Implicit>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::Fired);
 
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Implicit>();
+    let action = actions.get::<Implicit>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
+
+    Ok(())
 }
 
 #[test]
-fn blocker() {
+fn blocker() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
@@ -123,12 +127,12 @@ fn blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Blocker>();
+    let action = actions.get::<Blocker>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
@@ -139,12 +143,12 @@ fn blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Blocker>();
+    let action = actions.get::<Blocker>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -155,30 +159,32 @@ fn blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::Fired);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Blocker>();
+    let action = actions.get::<Blocker>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::None);
 
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<Blocker>();
+    let action = actions.get::<Blocker>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Fired);
+
+    Ok(())
 }
 
 #[test]
-fn events_blocker() {
+fn events_blocker() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
@@ -190,12 +196,12 @@ fn events_blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<EventsBlocker>();
+    let action = actions.get::<EventsBlocker>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
@@ -206,12 +212,12 @@ fn events_blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<EventsBlocker>();
+    let action = actions.get::<EventsBlocker>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -223,12 +229,12 @@ fn events_blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::Fired);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<EventsBlocker>();
+    let action = actions.get::<EventsBlocker>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -239,14 +245,16 @@ fn events_blocker() {
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<ReleaseAction>();
+    let action = actions.get::<ReleaseAction>()?;
     assert_eq!(action.value(), false.into());
     assert_eq!(action.state(), ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.action::<EventsBlocker>();
+    let action = actions.get::<EventsBlocker>()?;
     assert_eq!(action.value(), true.into());
     assert_eq!(action.state(), ActionState::Fired);
+
+    Ok(())
 }
 
 fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Player>>) {

--- a/tests/consume_input.rs
+++ b/tests/consume_input.rs
@@ -2,7 +2,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn consume() {
+fn consume() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<ConsumeOnly>()
@@ -27,18 +27,20 @@ fn consume() {
     app.update();
 
     let entity1_ctx = app.world().get::<Actions<ConsumeOnly>>(entity1).unwrap();
-    assert_eq!(entity1_ctx.action::<Consume>().state(), ActionState::Fired);
+    assert_eq!(entity1_ctx.state::<Consume>()?, ActionState::Fired);
 
     let entity2_ctx = app.world().get::<Actions<ConsumeOnly>>(entity2).unwrap();
     assert_eq!(
-        entity2_ctx.action::<Consume>().state(),
+        entity2_ctx.state::<Consume>()?,
         ActionState::None,
         "only first entity with the same mappings that consume inputs should receive them"
     );
+
+    Ok(())
 }
 
 #[test]
-fn passthrough() {
+fn passthrough() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<PassthroughOnly>()
@@ -66,24 +68,23 @@ fn passthrough() {
         .world()
         .get::<Actions<PassthroughOnly>>(entity1)
         .unwrap();
-    assert_eq!(
-        entity1_ctx.action::<Passthrough>().state(),
-        ActionState::Fired
-    );
+    assert_eq!(entity1_ctx.state::<Passthrough>()?, ActionState::Fired);
 
     let entity2_ctx = app
         .world()
         .get::<Actions<PassthroughOnly>>(entity2)
         .unwrap();
     assert_eq!(
-        entity2_ctx.action::<Passthrough>().state(),
+        entity2_ctx.state::<Passthrough>()?,
         ActionState::Fired,
         "actions that doesn't consume inputs should still fire"
     );
+
+    Ok(())
 }
 
 #[test]
-fn consume_then_passthrough() {
+fn consume_then_passthrough() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<ConsumeThenPassthrough>()
@@ -107,16 +108,18 @@ fn consume_then_passthrough() {
         .world()
         .get::<Actions<ConsumeThenPassthrough>>(entity)
         .unwrap();
-    assert_eq!(actions.action::<Consume>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<Consume>()?, ActionState::Fired);
     assert_eq!(
-        actions.action::<Passthrough>().state(),
+        actions.state::<Passthrough>()?,
         ActionState::None,
         "action should be consumed"
     );
+
+    Ok(())
 }
 
 #[test]
-fn passthrough_then_consume() {
+fn passthrough_then_consume() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<PassthroughThenConsume>()
@@ -140,8 +143,10 @@ fn passthrough_then_consume() {
         .world()
         .get::<Actions<PassthroughThenConsume>>(entity)
         .unwrap();
-    assert_eq!(actions.action::<Consume>().state(), ActionState::Fired);
-    assert_eq!(actions.action::<Passthrough>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<Consume>()?, ActionState::Fired);
+    assert_eq!(actions.state::<Passthrough>()?, ActionState::Fired);
+
+    Ok(())
 }
 
 fn consume_only_binding(

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -2,7 +2,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn any() {
+fn any() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<AnyGamepad>()
@@ -25,7 +25,7 @@ fn any() {
         .world()
         .get::<Actions<AnyGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<TestAction>()?, ActionState::Fired);
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
     gamepad1.analog_mut().set(TestAction::BUTTON, 0.0);
@@ -39,11 +39,13 @@ fn any() {
         .world()
         .get::<Actions<AnyGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<TestAction>()?, ActionState::Fired);
+
+    Ok(())
 }
 
 #[test]
-fn by_id() {
+fn by_id() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<SingleGamepad>()
@@ -72,7 +74,7 @@ fn by_id() {
         .world()
         .get::<Actions<SingleGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<TestAction>()?, ActionState::Fired);
 
     let mut gamepad1 = app.world_mut().get_mut::<Gamepad>(gamepad_entity1).unwrap();
     gamepad1.analog_mut().set(TestAction::BUTTON, 0.0);
@@ -86,7 +88,9 @@ fn by_id() {
         .world()
         .get::<Actions<SingleGamepad>>(context_entity)
         .unwrap();
-    assert_eq!(actions.action::<TestAction>().state(), ActionState::None);
+    assert_eq!(actions.state::<TestAction>()?, ActionState::None);
+
+    Ok(())
 }
 
 fn any_gamepad_binding(

--- a/tests/dim.rs
+++ b/tests/dim.rs
@@ -2,7 +2,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn bool() {
+fn bool() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -20,7 +20,7 @@ fn bool() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Bool>().value(), true.into());
+    assert_eq!(actions.value::<Bool>()?, true.into());
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
@@ -29,11 +29,13 @@ fn bool() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Bool>().value(), false.into());
+    assert_eq!(actions.value::<Bool>()?, false.into());
+
+    Ok(())
 }
 
 #[test]
-fn axis1d() {
+fn axis1d() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -51,7 +53,7 @@ fn axis1d() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Axis1D>().value(), 1.0.into());
+    assert_eq!(actions.value::<Axis1D>()?, 1.0.into());
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
@@ -60,11 +62,13 @@ fn axis1d() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Axis1D>().value(), 0.0.into());
+    assert_eq!(actions.value::<Axis1D>()?, 0.0.into());
+
+    Ok(())
 }
 
 #[test]
-fn axis2d() {
+fn axis2d() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -82,7 +86,7 @@ fn axis2d() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Axis2D>().value(), (1.0, 0.0).into());
+    assert_eq!(actions.value::<Axis2D>()?, (1.0, 0.0).into());
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
@@ -91,11 +95,13 @@ fn axis2d() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Axis2D>().value(), Vec2::ZERO.into());
+    assert_eq!(actions.value::<Axis2D>()?, Vec2::ZERO.into());
+
+    Ok(())
 }
 
 #[test]
-fn axis3d() {
+fn axis3d() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -113,7 +119,7 @@ fn axis3d() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Axis3D>().value(), (1.0, 0.0, 0.0).into());
+    assert_eq!(actions.value::<Axis3D>()?, (1.0, 0.0, 0.0).into());
 
     app.world_mut()
         .resource_mut::<ButtonInput<KeyCode>>()
@@ -122,7 +128,9 @@ fn axis3d() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<Axis3D>().value(), Vec3::ZERO.into());
+    assert_eq!(actions.value::<Axis3D>()?, Vec3::ZERO.into());
+
+    Ok(())
 }
 
 fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {

--- a/tests/fixed_timestep.rs
+++ b/tests/fixed_timestep.rs
@@ -2,7 +2,7 @@ use bevy::{input::InputPlugin, prelude::*, time::TimeUpdateStrategy};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn once_in_two_frames() {
+fn once_in_two_frames() -> Result<()> {
     let time_step = Time::<Fixed>::default().timestep() / 2;
 
     let mut app = App::new();
@@ -23,7 +23,7 @@ fn once_in_two_frames() {
 
         let actions = app.world().get::<Actions<Test>>(entity).unwrap();
         assert!(
-            actions.action::<TestAction>().events().is_empty(),
+            actions.events::<TestAction>()?.is_empty(),
             "shouldn't fire on frame {frame}"
         );
     }
@@ -32,17 +32,18 @@ fn once_in_two_frames() {
         app.update();
 
         let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-        let action = actions.action::<TestAction>();
         assert_eq!(
-            action.events(),
+            actions.events::<TestAction>()?,
             ActionEvents::STARTED | ActionEvents::FIRED,
             "should maintain start-firing on frame {frame}"
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn twice_in_one_frame() {
+fn twice_in_one_frame() -> Result<()> {
     let time_step = Time::<Fixed>::default().timestep() * 2;
 
     let mut app = App::new();
@@ -62,19 +63,20 @@ fn twice_in_one_frame() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert!(
-        actions.action::<TestAction>().events().is_empty(),
+        actions.events::<TestAction>()?.is_empty(),
         "`FixedMain` should never run on the first frame"
     );
 
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<TestAction>();
     assert_eq!(
-        action.events(),
+        actions.events::<TestAction>()?,
         ActionEvents::FIRED,
         "should run twice, so it shouldn't be started on the second run"
     );
+
+    Ok(())
 }
 
 fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -46,11 +46,11 @@ fn rebuild() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert!(actions.get_action::<TestAction>().is_some());
+    assert!(actions.get::<TestAction>().is_ok());
 }
 
 #[test]
-fn rebuild_all() {
+fn rebuild_all() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -68,17 +68,19 @@ fn rebuild_all() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<TestAction>()?, ActionState::Fired);
 
     app.world_mut().trigger(RebuildBindings);
     app.world_mut().flush();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(
-        actions.action::<TestAction>().state(),
+        actions.state::<TestAction>()?,
         ActionState::None,
         "state should reset on rebuild"
     );
+
+    Ok(())
 }
 
 fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -39,7 +39,7 @@ fn keys() {
 
         let actions = app.world().get::<Actions<Test>>(entity).unwrap();
         assert_eq!(
-            actions.action::<TestAction>().value(),
+            actions.value::<TestAction>().unwrap(),
             dir.into(),
             "`{key:?}` should result in `{dir}`"
         );
@@ -78,7 +78,7 @@ fn dpad() {
 
         let actions = app.world().get::<Actions<Test>>(ctx_entity).unwrap();
         assert_eq!(
-            actions.action::<TestAction>().value(),
+            actions.value::<TestAction>().unwrap(),
             dir.into(),
             "`{button:?}` should result in `{dir}`"
         );
@@ -117,7 +117,7 @@ fn sticks() {
 
             let actions = app.world().get::<Actions<Test>>(ctx_entity).unwrap();
             assert_eq!(
-                actions.action::<TestAction>().value(),
+                actions.value::<TestAction>().unwrap(),
                 dir.into(),
                 "`{axis:?}` should result in `{dir}`"
             );

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -2,7 +2,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn prioritization() {
+fn prioritization() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
@@ -25,23 +25,22 @@ fn prioritization() {
     app.update();
 
     let first = app.world().get::<Actions<First>>(entity).unwrap();
-    assert_eq!(first.action::<FirstConsume>().state(), ActionState::Fired);
-    assert_eq!(
-        first.action::<FirstPassthrough>().state(),
-        ActionState::Fired
-    );
+    assert_eq!(first.state::<FirstConsume>()?, ActionState::Fired);
+    assert_eq!(first.state::<FirstPassthrough>()?, ActionState::Fired);
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
     assert_eq!(
-        second.action::<SecondConsume>().state(),
+        second.state::<SecondConsume>()?,
         ActionState::None,
         "action should be consumed by component input with a higher priority"
     );
     assert_eq!(
-        second.action::<SecondPassthrough>().state(),
+        second.state::<SecondPassthrough>()?,
         ActionState::Fired,
         "actions that doesn't consume inputs should still be triggered"
     );
+
+    Ok(())
 }
 
 fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {

--- a/tests/require_reset.rs
+++ b/tests/require_reset.rs
@@ -2,7 +2,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn layering() {
+fn layering() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
@@ -25,10 +25,10 @@ fn layering() {
     app.update();
 
     let first = app.world().get::<Actions<First>>(entity).unwrap();
-    assert_eq!(first.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(first.state::<TestAction>()?, ActionState::Fired);
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
-    assert_eq!(second.action::<TestAction>().state(), ActionState::None);
+    assert_eq!(second.state::<TestAction>()?, ActionState::None);
 
     app.world_mut()
         .entity_mut(entity)
@@ -38,7 +38,7 @@ fn layering() {
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
     assert_eq!(
-        second.action::<TestAction>().state(),
+        second.state::<TestAction>()?,
         ActionState::None,
         "action should still be consumed even after removal"
     );
@@ -56,11 +56,13 @@ fn layering() {
     app.update();
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
-    assert_eq!(second.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(second.state::<TestAction>()?, ActionState::Fired);
+
+    Ok(())
 }
 
 #[test]
-fn switching() {
+fn switching() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
@@ -80,7 +82,7 @@ fn switching() {
     app.update();
 
     let actions = app.world().get::<Actions<First>>(entity).unwrap();
-    assert_eq!(actions.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(actions.state::<TestAction>()?, ActionState::Fired);
 
     app.world_mut()
         .entity_mut(entity)
@@ -91,7 +93,7 @@ fn switching() {
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
     assert_eq!(
-        second.action::<TestAction>().state(),
+        second.state::<TestAction>()?,
         ActionState::None,
         "action should still be consumed even after removal"
     );
@@ -109,7 +111,9 @@ fn switching() {
     app.update();
 
     let second = app.world().get::<Actions<Second>>(entity).unwrap();
-    assert_eq!(second.action::<TestAction>().state(), ActionState::Fired);
+    assert_eq!(second.state::<TestAction>()?, ActionState::Fired);
+
+    Ok(())
 }
 
 fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -4,7 +4,7 @@ use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 
 #[test]
-fn input_level() {
+fn input_level() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -22,7 +22,7 @@ fn input_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<InputLevel>();
+    let action = actions.get::<InputLevel>()?;
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
@@ -33,7 +33,7 @@ fn input_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<InputLevel>();
+    let action = actions.get::<InputLevel>()?;
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -44,7 +44,7 @@ fn input_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<InputLevel>();
+    let action = actions.get::<InputLevel>()?;
     assert_eq!(action.value(), Vec2::NEG_Y.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -55,7 +55,7 @@ fn input_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<InputLevel>();
+    let action = actions.get::<InputLevel>()?;
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -66,7 +66,7 @@ fn input_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<InputLevel>();
+    let action = actions.get::<InputLevel>()?;
     assert_eq!(action.value(), Vec2::ZERO.into());
     assert_eq!(
         action.state(),
@@ -82,13 +82,15 @@ fn input_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<InputLevel>();
+    let action = actions.get::<InputLevel>()?;
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
+
+    Ok(())
 }
 
 #[test]
-fn action_level() {
+fn action_level() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -106,7 +108,7 @@ fn action_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<ActionLevel>();
+    let action = actions.get::<ActionLevel>()?;
     assert_eq!(action.value(), (Vec2::NEG_Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
@@ -117,7 +119,7 @@ fn action_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<ActionLevel>();
+    let action = actions.get::<ActionLevel>()?;
     assert_eq!(action.value(), (Vec2::NEG_Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -128,7 +130,7 @@ fn action_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<ActionLevel>();
+    let action = actions.get::<ActionLevel>()?;
     assert_eq!(action.value(), (Vec2::NEG_Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -139,7 +141,7 @@ fn action_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<ActionLevel>();
+    let action = actions.get::<ActionLevel>()?;
     assert_eq!(action.value(), (Vec2::NEG_Y * 4.0).into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -150,7 +152,7 @@ fn action_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<ActionLevel>();
+    let action = actions.get::<ActionLevel>()?;
     assert_eq!(action.value(), (Vec2::NEG_Y * 4.0).into());
     assert_eq!(
         action.state(),
@@ -166,13 +168,15 @@ fn action_level() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<ActionLevel>();
+    let action = actions.get::<ActionLevel>()?;
     assert_eq!(action.value(), (Vec2::NEG_Y * 4.0).into());
     assert_eq!(action.state(), ActionState::Fired);
+
+    Ok(())
 }
 
 #[test]
-fn both_levels() {
+fn both_levels() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
@@ -190,7 +194,7 @@ fn both_levels() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<BothLevels>();
+    let action = actions.get::<BothLevels>()?;
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Ongoing);
 
@@ -201,7 +205,7 @@ fn both_levels() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<BothLevels>();
+    let action = actions.get::<BothLevels>()?;
     assert_eq!(action.value(), (Vec2::Y * 2.0).into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -212,7 +216,7 @@ fn both_levels() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<BothLevels>();
+    let action = actions.get::<BothLevels>()?;
     assert_eq!(action.value(), Vec2::NEG_Y.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -223,7 +227,7 @@ fn both_levels() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<BothLevels>();
+    let action = actions.get::<BothLevels>()?;
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
 
@@ -234,7 +238,7 @@ fn both_levels() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<BothLevels>();
+    let action = actions.get::<BothLevels>()?;
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(
         action.state(),
@@ -250,9 +254,11 @@ fn both_levels() {
     app.update();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
-    let action = actions.action::<BothLevels>();
+    let action = actions.get::<BothLevels>()?;
     assert_eq!(action.value(), Vec2::Y.into());
     assert_eq!(action.state(), ActionState::Fired);
+
+    Ok(())
 }
 
 fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {


### PR DESCRIPTION
- Follow Bevy's shift away from panicking methods.
- Rename `Actions::action` into `Actions::get`.
- Add helper methods for convenient action data access.