### PR TITLE
add time delta for Fired/Ongoing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-`Actions::state`, `Actions::value` and `Actions::events` helpers to obtain specific information for an action directly.
+- `Actions::state`, `Actions::value` and `Actions::events` helpers to obtain specific information for an action directly.
+- `delta` time to `Fire` and `Ongoing` events since the last time they were triggered in a sequence.
 
 ### Changed
 

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -49,7 +49,9 @@ pub struct Action {
     events: ActionEvents,
     value: ActionValue,
     elapsed_secs: f32,
+    elapsed_delta: f32,
     fired_secs: f32,
+    fired_delta: f32,
     trigger_events: fn(&Self, &mut Commands, Entity),
 }
 
@@ -64,7 +66,9 @@ impl Action {
             events: ActionEvents::empty(),
             value: ActionValue::zero(A::Output::DIM),
             elapsed_secs: 0.0,
+            elapsed_delta: 0.0,
             fired_secs: 0.0,
+            fired_delta: 0.0,
             trigger_events: Self::trigger_events_typed::<A>,
         }
     }
@@ -79,17 +83,23 @@ impl Action {
         match self.state {
             ActionState::None => {
                 self.elapsed_secs = 0.0;
+                self.elapsed_delta = 0.0;
                 self.fired_secs = 0.0;
+                self.fired_delta = 0.0;
             }
             ActionState::Ongoing => {
                 self.elapsed_secs += time.delta_secs();
-                self.fired_secs = 0.0;
+                self.elapsed_delta = 0.0;
+                self.fired_secs = time.delta_secs();
+                self.fired_delta = 0.0;
             }
             ActionState::Fired => {
                 self.elapsed_secs += time.delta_secs();
+                self.elapsed_delta = time.delta_secs();
                 self.fired_secs += time.delta_secs();
+                self.fired_delta = time.delta_secs();
             }
-        }
+        };
 
         self.events = ActionEvents::new(self.state, state);
         self.state = state;
@@ -125,6 +135,7 @@ impl Action {
                             value: A::Output::as_output(self.value),
                             state: self.state,
                             elapsed_secs: self.elapsed_secs,
+                            delta: self.elapsed_delta,
                         },
                     );
                 }
@@ -137,6 +148,7 @@ impl Action {
                             state: self.state,
                             fired_secs: self.fired_secs,
                             elapsed_secs: self.elapsed_secs,
+                            delta: self.fired_delta,
                         },
                     );
                 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -99,6 +99,9 @@ pub struct Ongoing<A: InputAction> {
 
     /// Time that this action has been in [`ActionState::Ongoing`] state.
     pub elapsed_secs: f32,
+
+    /// Time since that last event was triggered.
+    pub delta: f32,
 }
 
 impl<A: InputAction> Clone for Ongoing<A> {
@@ -126,6 +129,9 @@ pub struct Fired<A: InputAction> {
 
     /// Total time this action has been in both [`ActionState::Ongoing`] and [`ActionState::Fired`].
     pub elapsed_secs: f32,
+
+    /// Time since that last event was triggered.
+    pub delta: f32,
 }
 
 impl<A: InputAction> Clone for Fired<A> {


### PR DESCRIPTION
some input reaction are dependent on the duration since they were last triggered.

adds the deltas information to `Fired` and `Ongoing` events