### PR TITLE
Fix `ActionSources` example

### DIFF
--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -231,9 +231,9 @@ impl InputReader<'_, '_> {
 ///     mut action_sources: ResMut<ActionSources>,
 ///     interactions: Query<&Interaction>,
 /// ) {
-///     let mouse_used = interactions.iter().all(|&interaction| interaction == Interaction::None);
-///     action_sources.mouse_buttons = !mouse_used;
-///     action_sources.mouse_wheel = !mouse_used;
+///     let mouse_unused = interactions.iter().all(|&interaction| interaction == Interaction::None);
+///     action_sources.mouse_buttons = mouse_unused;
+///     action_sources.mouse_wheel = mouse_unused;
 /// }
 /// ```
 #[derive(Resource, Reflect)]


### PR DESCRIPTION
Hi, sorry to barge in with a pull request right away. This is such a small fix, I think it's hardly worth to write an issue first. If I'm wrong or you don't want my patch not much work will be wasted :)

Anyway, I was super excited to discover the `ActionSources` struct, but copying the example into my project broke mouse input. Looks like the condition is the wrong way around. Actually, we want to use the mouse for actions when there are no GUI interactions, right?

Cheers