### PR TITLE
Use `crate::prelude::*`

### DIFF
--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -8,20 +8,14 @@ use bevy::prelude::*;
 use log::{debug, trace};
 
 use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::{ActionValue, ActionValueDim},
-    input::Input,
-    input_action::{Accumulation, ActionOutput, InputAction},
-    input_binding::{InputBinding, IntoBindings},
-    input_condition::{InputCondition, IntoConditions},
-    input_modifier::{InputModifier, IntoModifiers},
-    input_reader::InputReader,
+    action_map::ActionMap, input_action::ActionOutput, input_condition::IntoConditions,
+    input_modifier::IntoModifiers, input_reader::InputReader, prelude::*,
     trigger_tracker::TriggerTracker,
 };
 
 /// Bindings associated with an [`InputAction`] marker.
 ///
-/// Stored inside [`Actions`](crate::actions::Actions).
+/// Stored inside [`Actions`].
 ///
 /// Bindings are stored separately from [`ActionMap`] to allow reading other actions' data during evaluation.
 ///
@@ -78,8 +72,7 @@ impl ActionBinding {
 
     /// Adds action-level modifiers.
     ///
-    /// For input-level modifiers see
-    /// [`BindingBuilder::with_modifiers`](crate::input_binding::BindingBuilder::with_modifiers).
+    /// For input-level modifiers see [`BindingBuilder::with_modifiers`].
     ///
     /// # Examples
     ///
@@ -125,8 +118,7 @@ impl ActionBinding {
 
     /// Adds action-level conditions.
     ///
-    /// For input-level conditions see
-    /// [`BindingBuilder::with_conditions`](crate::input_binding::BindingBuilder::with_conditions).
+    /// For input-level conditions see [`BindingBuilder::with_conditions`].
     ///
     /// # Examples
     ///
@@ -181,7 +173,7 @@ impl ActionBinding {
     ///    Also implemented on tuples, so you can pass multiple inputs to a single call.
     ///
     /// All assigned inputs will be evaluated separately (equivalent to "any of").
-    /// If you're looking for a chord, see the [`Chord`](crate::input_condition::chord::Chord) condition.
+    /// If you're looking for a chord, see the [`Chord`] condition.
     ///
     /// # Examples
     ///

--- a/src/action_instances.rs
+++ b/src/action_instances.rs
@@ -17,9 +17,8 @@ use bevy::{
 use log::{debug, trace};
 
 use crate::{
-    EnhancedInputSystem,
-    actions::{Actions, InputContext},
     input_reader::{InputReader, ResetInput},
+    prelude::*,
 };
 
 /// An extension trait for [`App`] to assign input to components.
@@ -404,7 +403,7 @@ impl<C: InputContext> Binding<C> {
 ///
 /// Use it when you change your application settings and want to reload the mappings.
 ///
-/// This will also reset all actions to [`ActionState::None`](crate::ActionState::None)
+/// This will also reset all actions to [`ActionState::None`]
 /// and trigger the corresponding events.
 #[derive(Event)]
 pub struct RebuildBindings;

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -7,18 +7,13 @@ use bevy::{platform::collections::HashMap, prelude::*};
 use log::debug;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    action_value::ActionValue,
-    events::{ActionEvents, Canceled, Completed, Fired, Ongoing, Started},
-    input_action::{ActionOutput, InputAction},
-};
+use crate::{input_action::ActionOutput, prelude::*};
 
 /// Maps markers that implement [`InputAction`] to their data (state, value, etc.).
 ///
-/// Stored inside [`Actions`](crate::actions::Actions).
+/// Stored inside [`Actions`].
 ///
-/// Accessible from [`InputCondition::evaluate`](crate::input_condition::InputCondition::evaluate)
-/// and [`InputModifier::apply`](crate::input_modifier::InputModifier::apply)
+/// Accessible from [`InputCondition::evaluate`] and [`InputModifier::apply`].
 #[derive(Default, Deref, DerefMut)]
 pub struct ActionMap(pub HashMap<TypeId, Action>);
 
@@ -217,8 +212,8 @@ pub enum ActionState {
     None,
     /// Condition has started triggering, but has not yet finished.
     ///
-    /// For example, [`Hold`](crate::input_condition::hold::Hold) condition
-    /// requires its state to be maintained over several frames.
+    /// For example, [`Hold`] condition requires its state to be
+    /// maintained over several frames.
     Ongoing,
     /// The condition has been met.
     Fired,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -9,13 +9,9 @@ use core::{
 use bevy::{ecs::schedule::ScheduleLabel, platform::collections::hash_map::Entry, prelude::*};
 
 use crate::{
-    action_binding::ActionBinding,
-    action_map::{Action, ActionMap, ActionState},
-    action_value::ActionValue,
-    events::ActionEvents,
-    input::GamepadDevice,
-    input_action::InputAction,
+    action_map::ActionMap,
     input_reader::{InputReader, ResetInput},
+    prelude::*,
 };
 
 /// Component that stores actions with their bindings for a specific [`InputContext`].
@@ -192,12 +188,12 @@ impl<C: InputContext, A: InputAction> Error for NoActionError<C, A> {}
 ///
 /// Used to differentiate [`Actions`] components and configure how associated actions will be evaluated.
 ///
-/// All structs that implement this trait need to be registered using
-/// [`InputContextAppExt::add_input_context`](crate::action_instances::InputContextAppExt::add_input_context)
+/// All structs that implement this trait need to be registered
+/// using [`InputContextAppExt::add_input_context`].
 ///
 /// # Examples
 ///
-/// To implement the trait you can use the [`InputContext`](bevy_enhanced_input_macros::InputContext)
+/// To implement the trait you can use the [`InputContext`]
 /// derive to reduce boilerplate:
 ///
 /// ```
@@ -226,9 +222,8 @@ pub trait InputContext: Send + Sync + 'static {
     ///
     /// Set this to [`FixedPreUpdate`] if game logic relies on actions from this context
     /// in [`FixedUpdate`]. For example, if [`FixedMain`](bevy::app::FixedMain) runs twice
-    /// in a single frame and an action triggers, you will get [`Started`](crate::events::Started)
-    /// and [`Fired`](crate::events::Fired) on the first run and only [`Fired`](crate::events::Fired)
-    /// on the second run.
+    /// in a single frame and an action triggers, you will get [`Started`]
+    /// and [`Fired`] on the first run and only [`Fired`] on the second run.
     type Schedule: ScheduleLabel + Default;
 
     /// Determines the evaluation order of [`Actions<Self>`].

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,12 +3,12 @@ use core::fmt::Debug;
 use bevy::prelude::*;
 use bitflags::bitflags;
 
-use crate::{action_map::ActionState, input_action::InputAction};
+use crate::prelude::*;
 
 bitflags! {
     /// Bitset with events triggered by updating [`ActionState`] for an action.
     ///
-    /// Stored inside [`Action`](crate::action_map::Action).
+    /// Stored inside [`Action`].
     ///
     /// On transition, events will be triggered with dedicated types that correspond to bitflags.
     ///
@@ -26,7 +26,7 @@ bitflags! {
     /// | [`ActionState::Fired`]      | [`ActionState::Ongoing`] | [`Ongoing`]               |
     /// | [`ActionState::Fired`]      | [`ActionState::None`]    | [`Completed`]             |
     ///
-    /// The meaning of each kind depends on the assigned [`InputCondition`](crate::input_condition::InputCondition)s.
+    /// The meaning of each kind depends on the assigned [`InputCondition`]s.
     #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
     pub struct ActionEvents: u8 {
         /// Corresponds to [`Started`].
@@ -66,7 +66,7 @@ impl ActionEvents {
 ///
 /// Fired before [`Fired`] and [`Ongoing`].
 ///
-/// For example, with the [`Tap`](crate::input_condition::tap::Tap) condition, this event is triggered
+/// For example, with the [`Tap`] condition, this event is triggered
 /// only on the first press.
 #[derive(Debug, Event)]
 pub struct Started<A: InputAction> {
@@ -87,8 +87,8 @@ impl<A: InputAction> Copy for Started<A> {}
 
 /// Triggers every frame when an action state is [`ActionState::Ongoing`].
 ///
-/// For example, with the [`HoldAndRelease`](crate::input_condition::hold_and_release::HoldAndRelease) condition,
-/// this event is triggered while the user is holding down the button before the specified duration is reached.
+/// For example, with the [`HoldAndRelease`] condition, this event is triggered
+/// while the user is holding down the button before the specified duration is reached.
 #[derive(Debug, Event)]
 pub struct Ongoing<A: InputAction> {
     /// Current action value.
@@ -111,8 +111,8 @@ impl<A: InputAction> Copy for Ongoing<A> {}
 
 /// Triggers every frame when an action state is [`ActionState::Fired`].
 ///
-/// For example, with the [`Release`](crate::input_condition::release::Release) condition,
-/// this event is triggered when the user releases the key.
+/// For example, with the [`Release`] condition, this event is triggered
+/// when the user releases the key.
 #[derive(Debug, Event)]
 pub struct Fired<A: InputAction> {
     /// Current action value.
@@ -136,10 +136,10 @@ impl<A: InputAction> Clone for Fired<A> {
 
 impl<A: InputAction> Copy for Fired<A> {}
 
-/// Triggers when action switches its state from [`ActionState::Ongoing`] to [`ActionState::None`],
+/// Triggers when action switches its state from [`ActionState::Ongoing`] to [`ActionState::None`].
 ///
-/// For example, with the [`HoldAndRelease`](crate::input_condition::hold_and_release::HoldAndRelease) condition,
-/// this event is triggered if the user releases the button before the condition is triggered.
+/// For example, with the [`HoldAndRelease`] condition, this event is triggered
+/// if the user releases the button before the condition is triggered.
 #[derive(Debug, Event)]
 pub struct Canceled<A: InputAction> {
     /// Current action value.
@@ -160,10 +160,10 @@ impl<A: InputAction> Clone for Canceled<A> {
 
 impl<A: InputAction> Copy for Canceled<A> {}
 
-/// Triggers when action switches its state from [`ActionState::Fired`] to [`ActionState::None`],
+/// Triggers when action switches its state from [`ActionState::Fired`] to [`ActionState::None`].
 ///
-/// For example, with the [`Hold`](crate::input_condition::hold::Hold) condition,
-/// this event is triggered when the user releases the key.
+/// For example, with the [`Hold`] condition, this event is triggered
+/// when the user releases the key.
 #[derive(Debug, Event)]
 pub struct Completed<A: InputAction> {
     /// Current action value.
@@ -193,7 +193,6 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::action_map::Action;
 
     #[test]
     fn none_none() {

--- a/src/input_action.rs
+++ b/src/input_action.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use bevy::prelude::*;
 
-use crate::action_value::{ActionValue, ActionValueDim};
+use crate::prelude::*;
 
 /// Marker for a gameplay-related action.
 ///
@@ -38,16 +38,14 @@ pub trait InputAction: Debug + Send + Sync + 'static {
     /// - For multi-axis actions, like `Move`, use [`Vec2`] or [`Vec3`].
     ///
     /// This type will also be used for `value` field on events
-    /// e.g. [`Fired::value`](crate::events::Fired::value),
-    /// [`Canceled::value`](crate::events::Canceled::value).
+    /// e.g. [`Fired::value`], [`Canceled::value`].
     type Output: ActionOutput;
 
-    /// Specifies whether this action should swallow any [`Input`](crate::input::Input)s
+    /// Specifies whether this action should swallow any [`Input`]s
     /// bound to it or allow them to pass through to affect other actions.
     ///
     /// Inputs are consumed when the action state is not equal to
-    /// [`ActionState::None`](crate::action_map::ActionState::None).
-    /// For details, see [`Actions`](crate::actions::Actions).
+    /// [`ActionState::None`]. For details, see [`Actions`].
     ///
     /// Consuming is global and affect actions in all contexts.
     const CONSUME_INPUT: bool = true;
@@ -122,8 +120,7 @@ impl ActionOutput for Vec3 {
 }
 
 /// Defines how [`ActionValue`] is calculated when multiple inputs are evaluated with the
-/// same most significant [`ActionState`](crate::action_map::ActionState)
-/// (excluding [`ActionState::None`](crate::action_map::ActionState::None)).
+/// same most significant [`ActionState`] (excluding [`ActionState::None`]).
 #[derive(Default, Clone, Copy, Debug)]
 pub enum Accumulation {
     /// Cumulatively add the key values for each mapping.

--- a/src/input_binding.rs
+++ b/src/input_binding.rs
@@ -1,13 +1,9 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::iter;
 
-use crate::{
-    input::Input,
-    input_condition::{InputCondition, IntoConditions},
-    input_modifier::{InputModifier, IntoModifiers},
-};
+use crate::{input_condition::IntoConditions, input_modifier::IntoModifiers, prelude::*};
 
-/// Associated input for [`ActionBinding`](crate::action_binding::ActionBinding).
+/// Associated input for [`ActionBinding`].
 #[derive(Debug)]
 pub struct InputBinding {
     pub input: Input,
@@ -151,8 +147,8 @@ pub trait IntoBindings {
     ///
     /// <div class="warning">
     ///
-    /// Avoid using this with modifiers like [`DeadZone`](crate::input_modifier::dead_zone::DeadZone),
-    /// as this method applies the modifier to each input **individually** rather than to all bindings.
+    /// Avoid using this with modifiers like [`DeadZone`], as this method applies
+    /// the modifier to each input **individually** rather than to all bindings.
     ///
     /// </div>
     ///

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -14,10 +14,7 @@ use core::{fmt::Debug, iter};
 
 use bevy::prelude::*;
 
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Default actuation threshold for all conditions.
 pub const DEFAULT_ACTUATION: f32 = 0.5;
@@ -29,8 +26,7 @@ pub const DEFAULT_ACTUATION: f32 = 0.5;
 /// or "release" events.
 ///
 /// Can be applied both to inputs and actions.
-/// See [`ActionBinding::with_conditions`](crate::action_binding::ActionBinding::with_conditions)
-/// and [`BindingBuilder::with_conditions`](crate::input_binding::BindingBuilder::with_conditions).
+/// See [`ActionBinding::with_conditions`] and [`BindingBuilder::with_conditions`].
 pub trait InputCondition: Sync + Send + Debug + 'static {
     /// Returns calculates state.
     ///
@@ -51,10 +47,10 @@ pub trait InputCondition: Sync + Send + Debug + 'static {
 /// Determines how a condition contributes to the final [`ActionState`].
 ///
 /// If no conditions are provided, the state will be set to [`ActionState::Fired`]
-/// on any non-zero value, functioning similarly to a [`Down`](press::Down) condition
+/// on any non-zero value, functioning similarly to a [`Down`] condition
 /// with a zero actuation threshold.
 ///
-/// For details about how actions are combined, see [`Actions`](crate::actions::Actions).
+/// For details about how actions are combined, see [`Actions`].
 pub enum ConditionKind {
     /// The most significant [`ActionState`] from all explicit conditions will be the
     /// resulting state.
@@ -77,8 +73,7 @@ pub enum ConditionKind {
 }
 
 /// Conversion into iterator of bindings that could be passed into
-/// [`ActionBinding::with_conditions`](crate::action_binding::ActionBinding::with_conditions)
-/// and [`BindingBuilder::with_conditions`](crate::input_binding::BindingBuilder::with_conditions).
+/// [`ActionBinding::with_conditions`] and [`BindingBuilder::with_conditions`].
 pub trait IntoConditions {
     /// Returns an iterator over conditions.
     fn into_conditions(self) -> impl Iterator<Item = Box<dyn InputCondition>>;

--- a/src/input_condition/block_by.rs
+++ b/src/input_condition/block_by.rs
@@ -3,12 +3,7 @@ use core::{any, marker::PhantomData};
 use bevy::prelude::*;
 use log::warn;
 
-use super::{ConditionKind, InputCondition};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-    input_action::InputAction,
-};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Requires another action to not be fired within the same context.
 #[derive(Debug)]
@@ -88,7 +83,6 @@ mod tests {
     use bevy_enhanced_input_macros::InputAction;
 
     use super::*;
-    use crate::action_map::Action;
 
     #[test]
     fn block() {

--- a/src/input_condition/chord.rs
+++ b/src/input_condition/chord.rs
@@ -3,12 +3,7 @@ use core::{any, marker::PhantomData};
 use bevy::prelude::*;
 use log::warn;
 
-use super::{ConditionKind, InputCondition};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-    input_action::InputAction,
-};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Requires action `A` to be fired within the same context.
 ///
@@ -65,7 +60,6 @@ mod tests {
     use bevy_enhanced_input_macros::InputAction;
 
     use super::*;
-    use crate::action_map::{Action, ActionMap};
 
     #[test]
     fn chord() {

--- a/src/input_condition/hold.rs
+++ b/src/input_condition/hold.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition, condition_timer::ConditionTimer};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Returns [`ActionState::Ongoing`] when the input becomes actuated and
 /// [`ActionState::Fired`] when input remained actuated for [`Self::hold_time`] seconds.
@@ -95,7 +92,6 @@ mod tests {
     use core::time::Duration;
 
     use super::*;
-    use crate::action_map::ActionMap;
 
     #[test]
     fn hold() {

--- a/src/input_condition/hold_and_release.rs
+++ b/src/input_condition/hold_and_release.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition, condition_timer::ConditionTimer};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Returns [`ActionState::Ongoing`] when input becomes actuated and [`ActionState::Fired`]
 /// when the input is released after having been actuated for [`Self::hold_time`] seconds.
@@ -77,7 +74,6 @@ mod tests {
     use core::time::Duration;
 
     use super::*;
-    use crate::action_map::ActionMap;
 
     #[test]
     fn hold_and_release() {

--- a/src/input_condition/just_press.rs
+++ b/src/input_condition/just_press.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Like [`super::press::Down`] but returns [`ActionState::Fired`] only once until the next actuation.
 ///
@@ -53,7 +50,6 @@ impl InputCondition for Press {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::action_map::ActionMap;
 
     #[test]
     fn press() {

--- a/src/input_condition/press.rs
+++ b/src/input_condition/press.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Returns [`ActionState::Fired`] when the input exceeds the actuation threshold.
 #[derive(Clone, Copy, Debug)]
@@ -44,7 +41,6 @@ impl InputCondition for Down {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::action_map::ActionMap;
 
     #[test]
     fn down() {

--- a/src/input_condition/pulse.rs
+++ b/src/input_condition/pulse.rs
@@ -1,17 +1,13 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition, condition_timer::ConditionTimer};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Returns [`ActionState::Ongoing`] when input becomes actuated and [`ActionState::Fired`]
 /// each [`Self::interval`] seconds.
 ///
-/// Note: [`Completed`](crate::events::Completed) only fires
-/// when the repeat limit is reached or when input is released immediately after being triggered.
-/// Otherwise, [`Canceled`](crate::events::Canceled) is fired when input is released.
+/// Note: [`Completed`] only fires when the repeat limit is reached or when input is released
+/// immediately after being triggered. Otherwise, [`Canceled`] is fired when input is released.
 #[derive(Clone, Copy, Debug)]
 pub struct Pulse {
     /// Time in seconds between each triggering while input is held.
@@ -112,7 +108,6 @@ mod tests {
     use core::time::Duration;
 
     use super::*;
-    use crate::action_map::ActionMap;
 
     #[test]
     fn tap() {

--- a/src/input_condition/release.rs
+++ b/src/input_condition/release.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Returns [`ActionState::Ongoing`] when the input exceeds the actuation threshold and
 /// [`ActionState::Fired`] once when the input drops back below the actuation threshold.

--- a/src/input_condition/tap.rs
+++ b/src/input_condition/tap.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
-use super::{DEFAULT_ACTUATION, InputCondition, condition_timer::ConditionTimer};
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use super::DEFAULT_ACTUATION;
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Returns [`ActionState::Ongoing`] when input becomes actuated and [`ActionState::Fired`]
 /// when the input is released within the [`Self::release_time`] seconds.

--- a/src/input_modifier.rs
+++ b/src/input_modifier.rs
@@ -13,7 +13,7 @@ use core::{fmt::Debug, iter};
 
 use bevy::prelude::*;
 
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Pre-processor that alter the raw input values.
 ///
@@ -21,8 +21,7 @@ use crate::{action_map::ActionMap, action_value::ActionValue};
 /// or changing how input maps to axes.
 ///
 /// Can be applied both to inputs and actions.
-/// See [`ActionBinding::with_modifiers`](crate::action_binding::ActionBinding::with_modifiers)
-/// and [`BindingBuilder::with_modifiers`](crate::input_binding::BindingBuilder::with_modifiers).
+/// See [`ActionBinding::with_modifiers`] and [`BindingBuilder::with_modifiers`].
 pub trait InputModifier: Sync + Send + Debug + 'static {
     /// Returns pre-processed value.
     ///
@@ -36,8 +35,7 @@ pub trait InputModifier: Sync + Send + Debug + 'static {
 }
 
 /// Conversion into iterator of bindings that could be passed into
-/// [`ActionBinding::with_modifiers`](crate::action_binding::ActionBinding::with_modifiers)
-/// and [`BindingBuilder::with_modifiers`](crate::input_binding::BindingBuilder::with_modifiers).
+/// [`ActionBinding::with_modifiers`] and [`BindingBuilder::with_modifiers`].
 pub trait IntoModifiers {
     /// Returns an iterator over modifiers.
     fn into_modifiers(self) -> impl Iterator<Item = Box<dyn InputModifier>>;

--- a/src/input_modifier/accumulate_by.rs
+++ b/src/input_modifier/accumulate_by.rs
@@ -3,12 +3,7 @@ use core::{any, marker::PhantomData};
 use bevy::prelude::*;
 use log::warn;
 
-use super::InputModifier;
-use crate::{
-    InputAction,
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Produces accumulated value when another action is fired within the same context.
 ///
@@ -62,7 +57,6 @@ mod tests {
     use bevy_enhanced_input_macros::InputAction;
 
     use super::*;
-    use crate::action_map::Action;
 
     #[test]
     fn accumulation_active() {

--- a/src/input_modifier/clamp.rs
+++ b/src/input_modifier/clamp.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Restricts input to a certain interval independently along each axis.
 ///

--- a/src/input_modifier/dead_zone.rs
+++ b/src/input_modifier/dead_zone.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Remaps input values within the range [Self::lower_threshold] to [Self::upper_threshold] onto the range 0 to 1.
 /// Values outside this range are clamped.

--- a/src/input_modifier/delta_scale.rs
+++ b/src/input_modifier/delta_scale.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Multiplies the input value by delta time for this frame.
 ///

--- a/src/input_modifier/exponential_curve.rs
+++ b/src/input_modifier/exponential_curve.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Response curve exponential.
 ///

--- a/src/input_modifier/negate.rs
+++ b/src/input_modifier/negate.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Inverts value per axis.
 ///

--- a/src/input_modifier/scale.rs
+++ b/src/input_modifier/scale.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Scales input independently along each axis by a specified factor.
 ///

--- a/src/input_modifier/smooth_nudge.rs
+++ b/src/input_modifier/smooth_nudge.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Produces a smoothed value of the current and previous input value.
 ///

--- a/src/input_modifier/swizzle_axis.rs
+++ b/src/input_modifier/swizzle_axis.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 
-use super::InputModifier;
-use crate::{action_map::ActionMap, action_value::ActionValue};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Swizzle axis components of an input value.
 ///

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -8,10 +8,7 @@ use bevy::{
     prelude::*,
 };
 
-use crate::{
-    action_value::ActionValue,
-    input::{GamepadDevice, Input, ModKeys},
-};
+use crate::prelude::*;
 
 /// Input state for actions.
 ///
@@ -304,7 +301,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::{Input, input::InputModKeys};
 
     #[test]
     fn keyboard() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,8 @@ use bevy::{input::InputSystem, prelude::*};
 
 use action_instances::ContextRegistry;
 use input_reader::{ActionSources, ResetInput};
+
+#[cfg(doc)]
 use prelude::*;
 
 /// Initializes contexts and feeds inputs to them.

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -1,9 +1,6 @@
 use bevy::prelude::*;
 
-use crate::{
-    input_binding::{BindingBuilder, InputBinding, IntoBindings},
-    input_modifier::{negate::Negate, swizzle_axis::SwizzleAxis},
-};
+use crate::prelude::*;
 
 /// A preset to map buttons as 2-dimensional input.
 ///

--- a/src/trigger_tracker.rs
+++ b/src/trigger_tracker.rs
@@ -3,13 +3,7 @@ use alloc::boxed::Box;
 use bevy::prelude::*;
 use log::trace;
 
-use crate::{
-    action_map::{ActionMap, ActionState},
-    action_value::ActionValue,
-    input_action::Accumulation,
-    input_condition::{ConditionKind, InputCondition},
-    input_modifier::InputModifier,
-};
+use crate::{action_map::ActionMap, prelude::*};
 
 /// Helper to calculate [`ActionState`] based on its modifiers and conditions.
 ///


### PR DESCRIPTION
From what I can tell, this is fairly idiomatic. Benefits:
- No need to type full paths in docs for items from the prelude.
- Rust Analyzer suggests items from the prelude, no need to fight the tooling.
- It's shorter, and our internals now resemble the public API more closely.