### PR TITLE
Remove `events_only` from `BlockBy` and `Blocker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `BlockBy::events_only` and `ConditionKind::Blocker::events_only`. This functionality was added before the introduction of the pull-based API and caused inconsistencies in returned values. It was intended to be used with `Chord`. If you need an action to be part of a chord but only want to react to it when the chord is not active, just check its state in the observer.
+
 ## [0.12.0] - 2025-05-25
 
 ### Added

--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -62,14 +62,8 @@ fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test
         .bind::<TapAction>()
         .to(TapAction::KEY)
         .with_conditions(Tap::new(0.5));
-    actions
-        .bind::<ChordMember1>()
-        .to(ChordMember1::KEY)
-        .with_conditions(BlockBy::<ChordAction>::events_only()); // Don't trigger the action when the chord is active.
-    actions
-        .bind::<ChordMember2>()
-        .to(ChordMember2::KEY)
-        .with_conditions(BlockBy::<ChordAction>::events_only());
+    actions.bind::<ChordMember1>().to(ChordMember1::KEY);
+    actions.bind::<ChordMember2>().to(ChordMember2::KEY);
     actions.bind::<ChordAction>().with_conditions((
         Chord::<ChordMember1>::default(),
         Chord::<ChordMember2>::default(),

--- a/src/action_binding.rs
+++ b/src/action_binding.rs
@@ -357,9 +357,7 @@ impl ActionBinding {
         }
 
         action.update(time, state, value);
-        if !tracker.events_blocked() {
-            action.trigger_events(commands, entity);
-        }
+        action.trigger_events(commands, entity);
     }
 
     pub(crate) fn type_id(&self) -> TypeId {

--- a/src/input_condition.rs
+++ b/src/input_condition.rs
@@ -61,15 +61,10 @@ pub enum ConditionKind {
     /// Otherwise, the most significant state will be capped at [`ActionState::Ongoing`].
     Implicit,
     /// Any blocking condition that returns [`ActionState::None`] will override
-    /// the state with [`ActionState::None`] or block the events.
+    /// the state with [`ActionState::None`].
     ///
     /// Doesn't contribute to the state on its own.
-    Blocker {
-        /// Block only events instead of overriding the state.
-        ///
-        /// Other actions will be able to see the action state in [`ActionMap`].
-        events_only: bool,
-    },
+    Blocker,
 }
 
 /// Conversion into iterator of bindings that could be passed into

--- a/src/input_condition/block_by.rs
+++ b/src/input_condition/block_by.rs
@@ -10,33 +10,12 @@ use crate::{action_map::ActionMap, prelude::*};
 pub struct BlockBy<A: InputAction> {
     /// Action that blocks this condition when active.
     marker: PhantomData<A>,
-
-    /// Whether to block the state or only the events.
-    ///
-    /// By default set to false.
-    pub events_only: bool,
-}
-
-impl<A: InputAction> BlockBy<A> {
-    /// Block only events.
-    ///
-    /// For details, see [`ConditionKind::Blocker::events_only`].
-    ///
-    /// This can be used for chords to avoid triggering required actions.
-    /// Otherwise, the chord will register the release and cancel itself.
-    pub fn events_only() -> Self {
-        Self {
-            marker: PhantomData,
-            events_only: true,
-        }
-    }
 }
 
 impl<A: InputAction> Default for BlockBy<A> {
     fn default() -> Self {
         Self {
             marker: PhantomData,
-            events_only: false,
         }
     }
 }
@@ -72,9 +51,7 @@ impl<A: InputAction> InputCondition for BlockBy<A> {
     }
 
     fn kind(&self) -> ConditionKind {
-        ConditionKind::Blocker {
-            events_only: self.events_only,
-        }
+        ConditionKind::Blocker
     }
 }
 

--- a/src/trigger_tracker.rs
+++ b/src/trigger_tracker.rs
@@ -16,7 +16,6 @@ pub(crate) struct TriggerTracker {
     found_implicit: bool,
     all_implicits_fired: bool,
     blocked: bool,
-    events_blocked: bool,
 }
 
 impl TriggerTracker {
@@ -30,7 +29,6 @@ impl TriggerTracker {
             found_implicit: false,
             all_implicits_fired: true,
             blocked: false,
-            events_blocked: false,
         }
     }
 
@@ -73,13 +71,8 @@ impl TriggerTracker {
                     self.all_implicits_fired &= state == ActionState::Fired;
                     self.found_active |= state != ActionState::None;
                 }
-                ConditionKind::Blocker { events_only } => {
-                    let blocked = state == ActionState::None;
-                    if events_only {
-                        self.events_blocked |= blocked;
-                    } else {
-                        self.blocked |= blocked;
-                    }
+                ConditionKind::Blocker => {
+                    self.blocked |= state == ActionState::None;
                 }
             }
         }
@@ -109,10 +102,6 @@ impl TriggerTracker {
 
     pub(crate) fn value(&self) -> ActionValue {
         self.value
-    }
-
-    pub(crate) fn events_blocked(&self) -> bool {
-        self.events_blocked
     }
 
     /// Replaces the state with `other`.
@@ -149,6 +138,5 @@ impl TriggerTracker {
         self.found_implicit |= other.found_implicit;
         self.all_implicits_fired &= other.all_implicits_fired;
         self.blocked |= other.blocked;
-        self.events_blocked |= other.events_blocked;
     }
 }

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -1,5 +1,3 @@
-use core::any;
-
 use bevy::{input::InputPlugin, prelude::*};
 use bevy_enhanced_input::prelude::*;
 use test_log::test;
@@ -184,80 +182,6 @@ fn blocker() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn events_blocker() -> Result<()> {
-    let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
-        .add_input_context::<Player>()
-        .add_observer(binding)
-        .finish();
-
-    let entity = app.world_mut().spawn(Actions::<Player>::default()).id();
-
-    app.update();
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value(), false.into());
-    assert_eq!(action.state(), ActionState::None);
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<EventsBlocker>()?;
-    assert_eq!(action.value(), false.into());
-    assert_eq!(action.state(), ActionState::None);
-
-    let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
-    keys.press(ReleaseAction::KEY);
-    keys.press(EventsBlocker::KEY);
-
-    app.update();
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value(), true.into());
-    assert_eq!(action.state(), ActionState::Ongoing);
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<EventsBlocker>()?;
-    assert_eq!(action.value(), true.into());
-    assert_eq!(action.state(), ActionState::Fired);
-
-    app.world_mut()
-        .resource_mut::<ButtonInput<KeyCode>>()
-        .release(ReleaseAction::KEY);
-    let observers = panic_on_action_events::<EventsBlocker>(app.world_mut());
-
-    app.update();
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value(), false.into());
-    assert_eq!(action.state(), ActionState::Fired);
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<EventsBlocker>()?;
-    assert_eq!(action.value(), true.into());
-    assert_eq!(action.state(), ActionState::Fired);
-
-    for entity in observers {
-        app.world_mut().despawn(entity);
-    }
-
-    app.update();
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value(), false.into());
-    assert_eq!(action.state(), ActionState::None);
-
-    let actions = app.world().get::<Actions<Player>>(entity).unwrap();
-    let action = actions.get::<EventsBlocker>()?;
-    assert_eq!(action.value(), true.into());
-    assert_eq!(action.state(), ActionState::Fired);
-
-    Ok(())
-}
-
 fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Player>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
@@ -275,10 +199,6 @@ fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Pl
         .bind::<Blocker>()
         .to(Blocker::KEY)
         .with_conditions(BlockBy::<ReleaseAction>::default());
-    actions
-        .bind::<EventsBlocker>()
-        .to(EventsBlocker::KEY)
-        .with_conditions(BlockBy::<ReleaseAction>::events_only());
 }
 
 #[derive(InputContext)]
@@ -310,29 +230,4 @@ struct Blocker;
 
 impl Blocker {
     const KEY: KeyCode = KeyCode::KeyD;
-}
-
-#[derive(Debug, InputAction)]
-#[input_action(output = bool)]
-struct EventsBlocker;
-
-impl EventsBlocker {
-    const KEY: KeyCode = KeyCode::KeyE;
-}
-
-fn panic_on_action_events<A: InputAction>(world: &mut World) -> [Entity; 5] {
-    [
-        world.add_observer(panic_on_event::<Started<A>>).id(),
-        world.add_observer(panic_on_event::<Ongoing<A>>).id(),
-        world.add_observer(panic_on_event::<Fired<A>>).id(),
-        world.add_observer(panic_on_event::<Completed<A>>).id(),
-        world.add_observer(panic_on_event::<Canceled<A>>).id(),
-    ]
-}
-
-fn panic_on_event<E: Event>(_trigger: Trigger<E>) {
-    panic!(
-        "event for action `{}` shouldn't trigger",
-        any::type_name::<E>()
-    );
 }


### PR DESCRIPTION
This feature was introduced before the pull-based API and caused inconsistent return values. It was originally intended for use with `Chord`.

If an action needs to be part of a chord but should only trigger when the chord is inactive, its state can be checked directly in the observer.