### PR TITLE
Implement action mocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Actions::mock` and related methods to mock actions.
+
 ### Removed
 
 - `BlockBy::events_only` and `ConditionKind::Blocker::events_only`. This functionality was added before the introduction of the pull-based API and caused inconsistencies in returned values. It was intended to be used with `Chord`. If you need an action to be part of a chord but only want to react to it when the chord is not active, just check its state in the observer.
+- `ActionMap::insert`. Use the new action mocking API.
+- `Action::new`, `Action::trigger_events` and `Action::update` from the public API. Use the new action mocking API.
 
 ## [0.12.0] - 2025-05-25
 

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -27,10 +27,6 @@ impl ActionMap {
 /// Data associated with an [`InputAction`] marker.
 ///
 /// Stored inside [`ActionMap`].
-///
-/// This struct could also be created manually to track state for an action
-/// with externally sourced data (e.g., network). Use [`Self::update`] to apply
-/// the data followed by [`Self::trigger_events`].
 #[derive(Clone, Copy)]
 pub struct Action {
     state: ActionState,

--- a/src/action_map.rs
+++ b/src/action_map.rs
@@ -15,19 +15,12 @@ use crate::{input_action::ActionOutput, prelude::*};
 ///
 /// Accessible from [`InputCondition::evaluate`] and [`InputModifier::apply`].
 #[derive(Default, Deref, DerefMut)]
-pub struct ActionMap(pub TypeIdMap<Action>);
+pub struct ActionMap(TypeIdMap<Action>);
 
 impl ActionMap {
     /// Returns associated state for action `A`.
     pub fn action<A: InputAction>(&self) -> Option<&Action> {
         self.get(&TypeId::of::<A>())
-    }
-
-    /// Inserts a state for action `A`.
-    ///
-    /// Returns previously associated state if present.
-    pub fn insert_action<A: InputAction>(&mut self, action: Action) -> Option<Action> {
-        self.insert(TypeId::of::<A>(), action)
     }
 }
 
@@ -53,7 +46,7 @@ impl Action {
     ///
     /// [`Self::trigger_events`] will trigger events for `A`.
     #[must_use]
-    pub fn new<A: InputAction>() -> Self {
+    pub(crate) fn new<A: InputAction>() -> Self {
         Self {
             state: Default::default(),
             events: ActionEvents::empty(),
@@ -65,7 +58,7 @@ impl Action {
     }
 
     /// Updates internal state.
-    pub fn update(
+    pub(crate) fn update(
         &mut self,
         time: &Time<Virtual>,
         state: ActionState,
@@ -94,7 +87,7 @@ impl Action {
     /// Triggers events resulting from a state transition after [`Self::update`].
     ///
     /// See also [`Self::new`] and [`ActionEvents`].
-    pub fn trigger_events(&self, commands: &mut Commands, entity: Entity) {
+    pub(crate) fn trigger_events(&self, commands: &mut Commands, entity: Entity) {
         (self.trigger_events)(self, commands, entity);
     }
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -74,7 +74,7 @@ impl<C: InputContext> Actions<C> {
     /// [`Self::bind`] beforehand is not required.
     ///
     /// Mocking won't take effect immediately - it will be applied on the next context evaluation.
-    /// See [`InputContext::schedule`] for details.
+    /// See [`InputContext::Schedule`] for details.
     ///
     /// # Examples
     ///

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -57,6 +57,58 @@ impl<C: InputContext> Actions<C> {
         }
     }
 
+    /// Like [`Self::mock`], but sets the value only for a single context evaluation.
+    pub fn mock_once<A: InputAction>(&mut self, state: ActionState, value: A::Output) {
+        self.mock::<A>(state, value, MockSpan::Updates(1));
+    }
+
+    /// Mocks the state and value of a specific action for a given span.
+    ///
+    /// While mocked, the action will skip input evaluation, conditions, and modifiers,
+    /// and instead report the provided state and value. All state transition events will be
+    /// triggered as usual.
+    ///
+    /// Once the span expires, the action will resume evaluating real input.
+    ///
+    /// The action will be created if it doesn't already exist in the context, so calling
+    /// [`Self::bind`] beforehand is not required.
+    ///
+    /// Mocking won't take effect immediately - it will be applied on the next context evaluation.
+    /// See [`InputContext::schedule`] for details.
+    ///
+    /// # Examples
+    ///
+    /// Move up for 2 seconds:
+    ///
+    /// ```
+    /// # use core::time::Duration;
+    /// # use bevy::prelude::*;
+    /// # use bevy_enhanced_input::prelude::*;
+    /// # let mut actions = Actions::<Player>::default();
+    /// actions.mock::<Move>(ActionState::Fired, Vec2::Y, Duration::from_secs(2));
+    /// # #[derive(InputContext)]
+    /// # struct Player;
+    /// # #[derive(Debug, InputAction)]
+    /// # #[input_action(output = Vec2)]
+    /// # struct Move;
+    /// ```
+    pub fn mock<A: InputAction>(
+        &mut self,
+        state: ActionState,
+        value: A::Output,
+        span: impl Into<MockSpan>,
+    ) {
+        self.bind::<A>().mock(state, value.into(), span.into());
+    }
+
+    /// Clears any active mock for the specified action.
+    ///
+    /// The action will be resume evaluating real input.
+    /// See also [`Self::mock`].
+    pub fn clear_mock<A: InputAction>(&mut self) {
+        self.bind::<A>().clear_mock();
+    }
+
     /// Returns the associated bindings for action `A` if exists.
     ///
     /// Use [`Self::bind`] to assign bindings.

--- a/src/input_action.rs
+++ b/src/input_action.rs
@@ -63,7 +63,7 @@ pub trait InputAction: Debug + Send + Sync + 'static {
 }
 
 /// Marks a type which can be used as [`InputAction::Output`].
-pub trait ActionOutput: Send + Sync + Debug + Clone + Copy {
+pub trait ActionOutput: Send + Sync + Debug + Clone + Copy + Into<ActionValue> {
     /// Dimension of this output.
     const DIM: ActionValueDim;
 

--- a/src/input_condition/block_by.rs
+++ b/src/input_condition/block_by.rs
@@ -57,6 +57,8 @@ impl<A: InputAction> InputCondition for BlockBy<A> {
 
 #[cfg(test)]
 mod tests {
+    use core::any::TypeId;
+
     use bevy_enhanced_input_macros::InputAction;
 
     use super::*;
@@ -68,7 +70,7 @@ mod tests {
         let time = Time::default();
         action.update(&time, ActionState::Fired, true);
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<TestAction>(action);
+        action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(
             condition.evaluate(&action_map, &time, true.into()),

--- a/src/input_condition/chord.rs
+++ b/src/input_condition/chord.rs
@@ -57,6 +57,8 @@ impl<A: InputAction> InputCondition for Chord<A> {
 
 #[cfg(test)]
 mod tests {
+    use core::any::TypeId;
+
     use bevy_enhanced_input_macros::InputAction;
 
     use super::*;
@@ -68,7 +70,7 @@ mod tests {
         let time = Time::default();
         action.update(&time, ActionState::Fired, true);
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<TestAction>(action);
+        action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(
             condition.evaluate(&action_map, &time, true.into()),

--- a/src/input_modifier/accumulate_by.rs
+++ b/src/input_modifier/accumulate_by.rs
@@ -54,6 +54,8 @@ impl<A: InputAction> InputModifier for AccumulateBy<A> {
 
 #[cfg(test)]
 mod tests {
+    use core::any::TypeId;
+
     use bevy_enhanced_input_macros::InputAction;
 
     use super::*;
@@ -65,7 +67,7 @@ mod tests {
         let time = Time::default();
         action.update(&time, ActionState::Fired, true);
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<TestAction>(action);
+        action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 2.0.into());
@@ -77,7 +79,7 @@ mod tests {
         let action = Action::new::<TestAction>();
         let time = Time::default();
         let mut action_map = ActionMap::default();
-        action_map.insert_action::<TestAction>(action);
+        action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ mod trigger_tracker;
 pub mod prelude {
     pub use super::{
         EnhancedInputPlugin, EnhancedInputSystem,
-        action_binding::ActionBinding,
+        action_binding::{ActionBinding, MockSpan},
         action_instances::{Binding, InputContextAppExt, RebuildBindings},
         action_map::{Action, ActionState},
         action_value::{ActionValue, ActionValueDim},

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -1,0 +1,118 @@
+use std::time::Duration;
+
+use bevy::{input::InputPlugin, prelude::*, time::TimeUpdateStrategy};
+use bevy_enhanced_input::prelude::*;
+use test_log::test;
+
+#[test]
+fn updates() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+        .add_input_context::<Test>()
+        .finish();
+
+    let mut actions = Actions::<Test>::default();
+    actions.mock_once::<TestAction>(ActionState::Fired, true);
+    let entity = app.world_mut().spawn(actions).id();
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), true.into());
+    assert_eq!(action.state(), ActionState::Fired);
+    assert_eq!(action.events(), ActionEvents::FIRED | ActionEvents::STARTED);
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), false.into());
+    assert_eq!(action.state(), ActionState::None);
+    assert_eq!(action.events(), ActionEvents::COMPLETED);
+}
+
+#[test]
+fn duration() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+        .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(1)))
+        .add_input_context::<Test>()
+        .finish();
+
+    // Update once to get a non-zero delta-time.
+    app.update();
+
+    let mut actions = Actions::<Test>::default();
+    actions.mock::<TestAction>(ActionState::Fired, true, Duration::from_millis(2));
+    let entity = app.world_mut().spawn(actions).id();
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), true.into());
+    assert_eq!(action.state(), ActionState::Fired);
+    assert_eq!(action.events(), ActionEvents::FIRED | ActionEvents::STARTED);
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), true.into());
+    assert_eq!(action.state(), ActionState::Fired);
+    assert_eq!(action.events(), ActionEvents::FIRED);
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), false.into());
+    assert_eq!(action.state(), ActionState::None);
+    assert_eq!(action.events(), ActionEvents::COMPLETED);
+}
+
+#[test]
+fn manual() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+        .add_input_context::<Test>()
+        .finish();
+
+    let mut actions = Actions::<Test>::default();
+    actions.mock::<TestAction>(ActionState::Fired, true, MockSpan::Manual);
+    let entity = app.world_mut().spawn(actions).id();
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), true.into());
+    assert_eq!(action.state(), ActionState::Fired);
+    assert_eq!(action.events(), ActionEvents::FIRED | ActionEvents::STARTED);
+
+    app.update();
+
+    let mut actions = app.world_mut().get_mut::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), true.into());
+    assert_eq!(action.state(), ActionState::Fired);
+    assert_eq!(action.events(), ActionEvents::FIRED);
+
+    actions.clear_mock::<TestAction>();
+
+    app.update();
+
+    let actions = app.world().get::<Actions<Test>>(entity).unwrap();
+    let action = actions.get::<TestAction>().unwrap();
+    assert_eq!(action.value(), false.into());
+    assert_eq!(action.state(), ActionState::None);
+    assert_eq!(action.events(), ActionEvents::COMPLETED);
+}
+
+#[derive(InputContext)]
+struct Test;
+
+#[derive(Debug, InputAction)]
+#[input_action(output = bool, consume_input = true)]
+struct TestAction;

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{input::InputPlugin, prelude::*, time::TimeUpdateStrategy};
 use bevy_enhanced_input::prelude::*;


### PR DESCRIPTION
Adds statically-typed input mocking to replace the raw API for setting action values.

`ActionMap::insert` was removed entirely (instead of made `pub(crate)`) since it was only used in tests.

This feature is useful for networking, replays, and tests.