### PR TITLE
Add Ordinal preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Actions::mock` and related methods to mock actions.
+- Add duplicative swizzles to `SwizzleAxis.`
 
 ### Removed
 

--- a/src/input_modifier/swizzle_axis.rs
+++ b/src/input_modifier/swizzle_axis.rs
@@ -24,6 +24,26 @@ pub enum SwizzleAxis {
     YZX,
     /// Reorder all axes, Z first.
     ZXY,
+
+    /// Replace Z with Y.
+    XXY,
+    /// Replace Y and Z with X.
+    XXZ,
+    /// Replace X and Z with Y.
+    YYX,
+    /// Replace X and Z with Y and Z respectively.
+    YYZ,
+    /// Replace X and Y with Z.
+    ZZX,
+    /// Replace X and Y with Z and Y respectively.
+    ZZY,
+
+    /// Replace all axes with X.
+    XXX,
+    /// Replace all axes with Y.
+    YYY,
+    /// Replace all axes with Z.
+    ZZZ,
 }
 
 impl InputModifier for SwizzleAxis {
@@ -40,8 +60,15 @@ impl InputModifier for SwizzleAxis {
             }
             ActionValue::Axis1D(value) => match self {
                 SwizzleAxis::YXZ | SwizzleAxis::ZXY => (Vec2::Y * value).into(),
-                SwizzleAxis::ZYX | SwizzleAxis::YZX => (Vec3::Z * value).into(),
+                SwizzleAxis::ZYX | SwizzleAxis::YZX | SwizzleAxis::YYX | SwizzleAxis::ZZX => {
+                    (Vec3::Z * value).into()
+                }
                 SwizzleAxis::XZY => value.into(),
+                SwizzleAxis::XXY | SwizzleAxis::XXZ => Vec2::splat(value).into(),
+                SwizzleAxis::YYZ | SwizzleAxis::YYY | SwizzleAxis::ZZZ | SwizzleAxis::ZZY => {
+                    0.0.into()
+                }
+                SwizzleAxis::XXX => Vec3::splat(value).into(),
             },
             ActionValue::Axis2D(value) => match self {
                 SwizzleAxis::YXZ => value.yx().into(),
@@ -49,6 +76,15 @@ impl InputModifier for SwizzleAxis {
                 SwizzleAxis::XZY => (value.x, 0.0, value.y).into(),
                 SwizzleAxis::YZX => (value.y, 0.0, value.x).into(),
                 SwizzleAxis::ZXY => (0.0, value.x, value.y).into(),
+                SwizzleAxis::XXY => value.xxy().into(),
+                SwizzleAxis::XXZ => value.xx().into(),
+                SwizzleAxis::YYX => value.yyx().into(),
+                SwizzleAxis::YYZ => value.yy().into(),
+                SwizzleAxis::ZZX => (value.x * Vec3::Z).into(),
+                SwizzleAxis::ZZY => (value.y * Vec3::Z).into(),
+                SwizzleAxis::XXX => value.xxx().into(),
+                SwizzleAxis::YYY => value.yyy().into(),
+                SwizzleAxis::ZZZ => Vec2::ZERO.into(),
             },
             ActionValue::Axis3D(value) => match self {
                 SwizzleAxis::YXZ => value.yxz().into(),
@@ -56,6 +92,15 @@ impl InputModifier for SwizzleAxis {
                 SwizzleAxis::XZY => value.xzy().into(),
                 SwizzleAxis::YZX => value.yzx().into(),
                 SwizzleAxis::ZXY => value.zxy().into(),
+                SwizzleAxis::XXY => value.xxy().into(),
+                SwizzleAxis::XXZ => value.xxz().into(),
+                SwizzleAxis::YYX => value.yyx().into(),
+                SwizzleAxis::YYZ => value.yyz().into(),
+                SwizzleAxis::ZZX => value.zzx().into(),
+                SwizzleAxis::ZZY => value.zzy().into(),
+                SwizzleAxis::XXX => value.xxx().into(),
+                SwizzleAxis::YYY => value.yyy().into(),
+                SwizzleAxis::ZZZ => value.zzz().into(),
             },
         }
     }
@@ -193,6 +238,222 @@ mod tests {
         assert_eq!(
             modifier.apply(&action_map, &time, (0.0, 1.0, 2.0).into()),
             (2.0, 0.0, 1.0).into(),
+        );
+    }
+
+    #[test]
+    fn xxy() {
+        let mut modifier = SwizzleAxis::XXY;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(
+            modifier.apply(&action_map, &time, true.into()),
+            Vec2::splat(1.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, false.into()),
+            Vec2::splat(0.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, 3.0.into()),
+            Vec2::splat(3.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 5.0).into()),
+            (2.0, 2.0, 5.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 5.0, 7.0).into()),
+            (2.0, 2.0, 5.0).into()
+        );
+    }
+
+    #[test]
+    fn yyx() {
+        let mut modifier = SwizzleAxis::YYX;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(
+            modifier.apply(&action_map, &time, true.into()),
+            (Vec3::Z * 1.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, false.into()),
+            Vec3::ZERO.into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, 4.0.into()),
+            (Vec3::Z * 4.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (3.0, 6.0).into()),
+            (6.0, 6.0, 3.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (3.0, 6.0, 9.0).into()),
+            (6.0, 6.0, 3.0).into()
+        );
+    }
+
+    #[test]
+    fn xxz() {
+        let mut modifier = SwizzleAxis::XXZ;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(
+            modifier.apply(&action_map, &time, true.into()),
+            Vec2::splat(1.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, false.into()),
+            Vec2::splat(0.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, 3.5.into()),
+            Vec2::splat(3.5).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 4.0).into()),
+            (2.0, 2.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 4.0, 6.0).into()),
+            (2.0, 2.0, 6.0).into()
+        );
+    }
+
+    #[test]
+    fn yyz() {
+        let mut modifier = SwizzleAxis::YYZ;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(modifier.apply(&action_map, &time, true.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, false.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, 2.0.into()), 0.0.into());
+        assert_eq!(
+            modifier.apply(&action_map, &time, (1.0, 3.0).into()),
+            (3.0, 3.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (1.0, 3.0, 5.0).into()),
+            (3.0, 3.0, 5.0).into()
+        );
+    }
+
+    #[test]
+    fn zzx() {
+        let mut modifier = SwizzleAxis::ZZX;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(
+            modifier.apply(&action_map, &time, true.into()),
+            (Vec3::Z * 1.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, false.into()),
+            (Vec3::Z * 0.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, 7.0.into()),
+            (Vec3::Z * 7.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (3.0, 5.0).into()),
+            (Vec3::Z * 3.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (3.0, 5.0, 8.0).into()),
+            (8.0, 8.0, 3.0).into()
+        );
+    }
+
+    #[test]
+    fn zzy() {
+        let mut modifier = SwizzleAxis::ZZY;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(modifier.apply(&action_map, &time, true.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, false.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, 4.0.into()), 0.0.into());
+        assert_eq!(
+            modifier.apply(&action_map, &time, (1.0, 2.0).into()),
+            (2.0 * Vec3::Z).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (1.0, 2.0, 3.0).into()),
+            (3.0, 3.0, 2.0).into()
+        );
+    }
+
+    #[test]
+    fn xxx() {
+        let mut modifier = SwizzleAxis::XXX;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(
+            modifier.apply(&action_map, &time, true.into()),
+            Vec3::ONE.into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, false.into()),
+            Vec3::ZERO.into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, 1.0.into()),
+            Vec3::ONE.into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 3.0).into()),
+            Vec3::splat(2.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (4.0, 5.0, 6.0).into()),
+            Vec3::splat(4.0).into()
+        );
+    }
+
+    #[test]
+    fn yyy() {
+        let mut modifier = SwizzleAxis::YYY;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(modifier.apply(&action_map, &time, true.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, false.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 0.0.into());
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 3.0).into()),
+            Vec3::splat(3.0).into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (4.0, 5.0, 6.0).into()),
+            Vec3::splat(5.0).into()
+        );
+    }
+
+    #[test]
+    fn zzz() {
+        let mut modifier = SwizzleAxis::ZZZ;
+        let action_map = ActionMap::default();
+        let time = Time::default();
+
+        assert_eq!(modifier.apply(&action_map, &time, true.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, false.into()), 0.0.into());
+        assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 0.0.into());
+        assert_eq!(
+            modifier.apply(&action_map, &time, (2.0, 3.0).into()),
+            Vec2::ZERO.into()
+        );
+        assert_eq!(
+            modifier.apply(&action_map, &time, (4.0, 5.0, 6.0).into()),
+            Vec3::splat(6.0).into()
         );
     }
 }

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -263,3 +263,92 @@ impl<I: IntoBindings> IntoBindings for Spatial<I> {
         )
     }
 }
+
+/// A preset to 8 map buttons as 2-dimensional input.
+///
+/// See [`Cardinal`] for a usage example.
+#[derive(Debug, Clone, Copy)]
+pub struct Ordinal<I: IntoBindings> {
+    pub north: I,
+    pub north_east: I,
+    pub east: I,
+    pub south_east: I,
+    pub south: I,
+    pub south_west: I,
+    pub west: I,
+    pub north_west: I,
+}
+
+impl Ordinal<KeyCode> {
+    /// Maps numpad keys as 2-dimensional input.
+    pub fn numpad_keys() -> Self {
+        Self {
+            north: KeyCode::Numpad8,
+            north_east: KeyCode::Numpad9,
+            east: KeyCode::Numpad6,
+            south_east: KeyCode::Numpad3,
+            south: KeyCode::Numpad2,
+            south_west: KeyCode::Numpad1,
+            west: KeyCode::Numpad4,
+            north_west: KeyCode::Numpad7,
+        }
+    }
+
+    /// Maps HJKLYUBN keys as 2-dimensional input.
+    ///
+    /// ```text
+    /// y   k   u
+    ///   🡴 🡱 🡵
+    /// h 🡰 · 🡲 l
+    ///   🡷 🡳 🡶
+    /// b   j   n
+    /// ```
+    /// Common for roguelikes.
+    pub fn hjklyubn() -> Self {
+        Self {
+            north: KeyCode::KeyK,
+            north_east: KeyCode::KeyU,
+            east: KeyCode::KeyL,
+            south_east: KeyCode::KeyN,
+            south: KeyCode::KeyJ,
+            south_west: KeyCode::KeyB,
+            west: KeyCode::KeyH,
+            north_west: KeyCode::KeyY,
+        }
+    }
+}
+
+impl<I: IntoBindings> IntoBindings for Ordinal<I> {
+    fn into_bindings(self) -> impl Iterator<Item = InputBinding> {
+        let cardinal = Cardinal {
+            north: self.north,
+            east: self.east,
+            south: self.south,
+            west: self.west,
+        };
+
+        let north_east = self
+            .north_east
+            .into_bindings()
+            .map(|b| b.with_modifiers(SwizzleAxis::XXZ));
+        let south_east = self
+            .south_east
+            .into_bindings()
+            .map(|b| b.with_modifiers((SwizzleAxis::XXZ, Negate::y())));
+        let south_west = self
+            .south_west
+            .into_bindings()
+            .map(|b| b.with_modifiers((SwizzleAxis::XXZ, Negate::all())));
+        let north_west = self
+            .north_west
+            .into_bindings()
+            .map(|b| b.with_modifiers((SwizzleAxis::XXZ, Negate::x())));
+
+        cardinal
+            .into_bindings()
+            .chain(north_east)
+            .chain(south_east)
+            .chain(south_west)
+            .chain(north_west)
+    }
+}

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -2,15 +2,11 @@ use bevy::prelude::*;
 
 use crate::prelude::*;
 
-/// A preset to map buttons as 2-dimensional input.
-///
-/// Uses [`SwizzleAxis`] and [`Negate`] to bind inputs to cardinal directions.
+/// A preset to 4 map buttons as 2-dimensional input.
 ///
 /// In Bevy's 3D space, the -Z axis points forward and the +Z axis points
 /// toward the camera. To map movement correctly in 3D space for [`Transform::translation`],
 /// you will need to invert Y and apply it to Z inside your observer.
-///
-/// See also [`Axial`], [`Bidirectional`] and [`Spatial`].
 ///
 /// # Examples
 ///
@@ -62,8 +58,6 @@ pub struct Cardinal<I: IntoBindings> {
 
 impl Cardinal<KeyCode> {
     /// Maps WASD keys as 2-dimensional input.
-    ///
-    /// See also [`Self::arrow_keys`].
     #[must_use]
     pub fn wasd_keys() -> Self {
         Self {
@@ -75,8 +69,6 @@ impl Cardinal<KeyCode> {
     }
 
     /// Maps keyboard arrow keys as 2-dimensional input.
-    ///
-    /// See also [`Self::wasd_keys`].
     #[must_use]
     pub fn arrow_keys() -> Self {
         Self {
@@ -90,8 +82,6 @@ impl Cardinal<KeyCode> {
 
 impl Cardinal<GamepadButton> {
     /// Maps D-pad as 2-dimensional input.
-    ///
-    /// See also [`Self::wasd_keys`].
     #[must_use]
     pub fn dpad_buttons() -> Self {
         Self {
@@ -130,11 +120,7 @@ impl<I: IntoBindings> IntoBindings for Cardinal<I> {
     }
 }
 
-/// A preset to map axes as 2-dimensional input.
-///
-/// Uses [`SwizzleAxis`] to bind inputs to axes.
-///
-/// See also [`Cardinal`].
+/// A preset to map 2 axes as 2-dimensional input.
 ///
 /// # Examples
 ///
@@ -177,8 +163,6 @@ pub struct Axial<I: IntoBindings> {
 
 impl Axial<GamepadAxis> {
     /// Maps left stick as 2-dimensional input.
-    ///
-    /// See also [`Self::right_stick`].
     pub fn left_stick() -> Self {
         Self {
             x: GamepadAxis::LeftStickX,
@@ -187,8 +171,6 @@ impl Axial<GamepadAxis> {
     }
 
     /// Maps right stick as 2-dimensional input.
-    ///
-    /// See also [`Self::left_stick`].
     pub fn right_stick() -> Self {
         Self {
             x: GamepadAxis::RightStickX,
@@ -209,11 +191,9 @@ impl<I: IntoBindings> IntoBindings for Axial<I> {
     }
 }
 
-/// A preset to map buttons as 1-dimensional input.
+/// A preset to map 2 buttons as 1-dimensional input.
 ///
-/// Positive binding will be passed as is and negative will be reversed using [`Negate`].
-///
-/// See also [`Cardinal`] and [`Spatial`].
+/// See [`Cardinal`] for a usage example.
 #[derive(Debug, Clone, Copy)]
 pub struct Bidirectional<I: IntoBindings> {
     pub positive: I,
@@ -232,56 +212,9 @@ impl<I: IntoBindings> IntoBindings for Bidirectional<I> {
     }
 }
 
-/// A preset to map buttons as 3-dimensional input.
+/// A preset to map 6 buttons as 3-dimensional input.
 ///
-/// Uses [`SwizzleAxis`] and [`Negate`] to bind inputs to the Y and Z directions.
-///
-/// See also [`Cardinal`] and [`Bidirectional`].
-///
-/// # Examples
-///
-/// Map keyboard inputs into a 3D movement action.
-///
-/// ```
-/// use bevy::prelude::*;
-/// use bevy_enhanced_input::prelude::*;
-///
-/// fn binding(
-///     trigger: Trigger<Binding<FlyCamera>>,
-///     settings: Res<KeyboardSettings>,
-///     mut cameras: Query<&mut Actions<FlyCamera>>,
-/// ) {
-///     let mut actions = cameras.get_mut(trigger.target()).unwrap();
-///     actions.bind::<Move>().to(Spatial {
-///         forward: &settings.forward,
-///         right: &settings.right,
-///         backward: &settings.backward,
-///         left: &settings.left,
-///         up: &settings.up,
-///         down: &settings.down,
-///     });
-/// }
-///
-/// // We use `KeyCode` here because we are only interested in key presses.
-/// // But you can also use `Input` if you want to e.g.
-/// // combine mouse and keyboard input sources.
-/// #[derive(Resource)]
-/// struct KeyboardSettings {
-///     forward: Vec<KeyCode>,
-///     right: Vec<KeyCode>,
-///     backward: Vec<KeyCode>,
-///     left: Vec<KeyCode>,
-///     up: Vec<KeyCode>,
-///     down: Vec<KeyCode>,
-/// }
-///
-/// #[derive(InputContext)]
-/// struct FlyCamera;
-///
-/// #[derive(Debug, InputAction)]
-/// #[input_action(output = Vec3)]
-/// struct Move;
-/// ```
+/// See [`Cardinal`] for a usage example.
 #[derive(Debug, Clone, Copy)]
 pub struct Spatial<I: IntoBindings> {
     pub forward: I,
@@ -294,8 +227,6 @@ pub struct Spatial<I: IntoBindings> {
 
 impl Spatial<KeyCode> {
     /// Maps WASD keys for horizontal (XZ) inputs and takes in up/down mappings.
-    ///
-    /// See also [`Self::arrows_and`].
     pub fn wasd_and(up: KeyCode, down: KeyCode) -> Self {
         Spatial {
             forward: KeyCode::KeyW,
@@ -308,8 +239,6 @@ impl Spatial<KeyCode> {
     }
 
     /// Maps arrow keys for horizontal (XZ) inputs and takes in up/down mappings.
-    ///
-    /// See also [`Self::wasd_and`].
     pub fn arrows_and(up: KeyCode, down: KeyCode) -> Self {
         Spatial {
             forward: KeyCode::ArrowUp,

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -95,28 +95,20 @@ impl Cardinal<GamepadButton> {
 
 impl<I: IntoBindings> IntoBindings for Cardinal<I> {
     fn into_bindings(self) -> impl Iterator<Item = InputBinding> {
-        // Y
-        let north = self
-            .north
-            .into_bindings()
-            .map(|binding| binding.with_modifiers(SwizzleAxis::YXZ));
+        let x = Bidirectional {
+            positive: self.east,
+            negative: self.west,
+        };
 
-        // -X
-        let west = self
-            .west
-            .into_bindings()
-            .map(|binding| binding.with_modifiers(Negate::all()));
+        let y = Bidirectional {
+            positive: self.north,
+            negative: self.south,
+        };
 
-        // -Y
-        let south = self
-            .south
-            .into_bindings()
-            .map(|binding| binding.with_modifiers((Negate::all(), SwizzleAxis::YXZ)));
-
-        // X
-        let east = self.east.into_bindings();
-
-        north.chain(east).chain(south).chain(west)
+        x.into_bindings().chain(
+            y.into_bindings()
+                .map(|b| b.with_modifiers(SwizzleAxis::YXZ)),
+        )
     }
 }
 
@@ -185,7 +177,7 @@ impl<I: IntoBindings> IntoBindings for Axial<I> {
         let y = self
             .y
             .into_bindings()
-            .map(|binding| binding.with_modifiers(SwizzleAxis::YXZ));
+            .map(|b| b.with_modifiers(SwizzleAxis::YXZ));
 
         x.chain(y)
     }
@@ -206,7 +198,7 @@ impl<I: IntoBindings> IntoBindings for Bidirectional<I> {
         let negative = self
             .negative
             .into_bindings()
-            .map(|binding| binding.with_modifiers(Negate::all()));
+            .map(|b| b.with_modifiers(Negate::all()));
 
         positive.chain(negative)
     }
@@ -253,44 +245,21 @@ impl Spatial<KeyCode> {
 
 impl<I: IntoBindings> IntoBindings for Spatial<I> {
     fn into_bindings(self) -> impl Iterator<Item = InputBinding> {
-        // Z
-        let backward = self
-            .backward
-            .into_bindings()
-            .map(|binding| binding.with_modifiers(SwizzleAxis::ZYX));
+        let xy = Cardinal {
+            north: self.up,
+            east: self.right,
+            south: self.down,
+            west: self.left,
+        };
 
-        // -Z
-        let forward = self
-            .forward
-            .into_bindings()
-            .map(|binding| binding.with_modifiers((Negate::all(), SwizzleAxis::ZYX)));
+        let z = Bidirectional {
+            positive: self.backward,
+            negative: self.forward,
+        };
 
-        // X
-        let right = self.right.into_bindings();
-
-        // -X
-        let left = self
-            .left
-            .into_bindings()
-            .map(|binding| binding.with_modifiers(Negate::all()));
-
-        // Y
-        let up = self
-            .up
-            .into_bindings()
-            .map(|binding| binding.with_modifiers(SwizzleAxis::YXZ));
-
-        // -Y
-        let down = self
-            .down
-            .into_bindings()
-            .map(|binding| binding.with_modifiers((Negate::all(), SwizzleAxis::YXZ)));
-
-        backward
-            .chain(forward)
-            .chain(right)
-            .chain(left)
-            .chain(up)
-            .chain(down)
+        xy.into_bindings().chain(
+            z.into_bindings()
+                .map(|b| b.with_modifiers(SwizzleAxis::ZYX)),
+        )
     }
 }

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -31,6 +31,22 @@ fn keys() {
         (KeyCode::Digit3, RIGHT),
         (KeyCode::Digit4, UP),
         (KeyCode::Digit5, DOWN),
+        (KeyCode::KeyK, UP),
+        (KeyCode::KeyU, RIGHT_UP),
+        (KeyCode::KeyL, RIGHT),
+        (KeyCode::KeyN, RIGHT_DOWN),
+        (KeyCode::KeyJ, DOWN),
+        (KeyCode::KeyB, LEFT_DOWN),
+        (KeyCode::KeyH, LEFT),
+        (KeyCode::KeyY, LEFT_UP),
+        (KeyCode::Numpad8, UP),
+        (KeyCode::Numpad9, RIGHT_UP),
+        (KeyCode::Numpad6, RIGHT),
+        (KeyCode::Numpad3, RIGHT_DOWN),
+        (KeyCode::Numpad2, DOWN),
+        (KeyCode::Numpad1, LEFT_DOWN),
+        (KeyCode::Numpad4, LEFT),
+        (KeyCode::Numpad7, LEFT_UP),
     ] {
         app.world_mut()
             .resource_mut::<ButtonInput<KeyCode>>()
@@ -137,6 +153,10 @@ const BACKWARD: Vec3 = Vec3::Z;
 const FORWARD: Vec3 = Vec3::NEG_Z;
 const UP: Vec3 = Vec3::Y;
 const DOWN: Vec3 = Vec3::NEG_Y;
+const RIGHT_UP: Vec3 = Vec3::new(1.0, 1.0, 0.0);
+const RIGHT_DOWN: Vec3 = Vec3::new(1.0, -1.0, 0.0);
+const LEFT_DOWN: Vec3 = Vec3::new(-1.0, -1.0, 0.0);
+const LEFT_UP: Vec3 = Vec3::new(-1.0, 1.0, 0.0);
 
 fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
@@ -158,6 +178,8 @@ fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test
             up: KeyCode::Digit4,
             down: KeyCode::Digit5,
         },
+        Ordinal::hjklyubn(),
+        Ordinal::numpad_keys(),
     ));
 }
 


### PR DESCRIPTION
I added `Ordinal` preset, which is useful for roguelikes. Each commit is a separate but related change - I recommend reviewing them one by one.