### PR TITLE
Triggers rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `Binding` event into `Bind`.
+- Rename `RebuildBindings` event into `RebindAll`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Actions::mock` and related methods to mock actions.
 - Add duplicative swizzles to `SwizzleAxis.`
 
+### Changed
+
+- Rename `Binding` event into `Bind`.
+
 ### Removed
 
 - `BlockBy::events_only` and `ConditionKind::Blocker::events_only`. This functionality was added before the introduction of the pull-based API and caused inconsistencies in returned values. It was intended to be used with `Chord`. If you need an action to be part of a chord but only want to react to it when the chord is not active, just check its state in the observer.

--- a/examples/all_conditions.rs
+++ b/examples/all_conditions.rs
@@ -23,7 +23,7 @@ struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_input_context::<Test>()
-            .add_observer(binding)
+            .add_observer(bind)
             .add_systems(Startup, spawn);
     }
 }
@@ -32,7 +32,7 @@ fn spawn(mut commands: Commands) {
     commands.spawn(Actions::<Test>::default());
 }
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
         .bind::<PressAction>()

--- a/examples/context_layering.rs
+++ b/examples/context_layering.rs
@@ -8,8 +8,8 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_input_context::<Driving>()
-        .add_observer(regular_binding)
-        .add_observer(swimming_binding)
+        .add_observer(bind_regular)
+        .add_observer(bind_swimming)
         .add_observer(apply_movement)
         .add_observer(jump)
         .add_observer(exit_car)
@@ -23,7 +23,7 @@ fn spawn(mut commands: Commands) {
     commands.spawn(Actions::<Player>::default());
 }
 
-fn regular_binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Actions<Player>>) {
+fn bind_regular(trigger: Trigger<Bind<Player>>, mut players: Query<&mut Actions<Player>>) {
     let mut actions = players.get_mut(trigger.target()).unwrap();
     actions
         .bind::<Move>()
@@ -37,7 +37,7 @@ fn regular_binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Ac
         .to((KeyCode::Enter, GamepadButton::North));
 }
 
-fn swimming_binding(trigger: Trigger<Binding<Driving>>, mut players: Query<&mut Actions<Driving>>) {
+fn bind_swimming(trigger: Trigger<Bind<Driving>>, mut players: Query<&mut Actions<Driving>>) {
     let mut actions = players.get_mut(trigger.target()).unwrap();
     // `Player` has lower priority, so `Brake` and `ExitCar` consume inputs first,
     // preventing `Rotate` and `EnterWater` from being triggered.

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -8,8 +8,8 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_input_context::<Inventory>()
-        .add_observer(player_binding)
-        .add_observer(inventory_binding)
+        .add_observer(bind_player)
+        .add_observer(bind_inventory)
         .add_observer(apply_movement)
         .add_observer(attack)
         .add_observer(open_inventory)
@@ -23,7 +23,7 @@ fn spawn(mut commands: Commands) {
     commands.spawn(Actions::<Player>::default());
 }
 
-fn player_binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Actions<Player>>) {
+fn bind_player(trigger: Trigger<Bind<Player>>, mut players: Query<&mut Actions<Player>>) {
     let mut actions = players.get_mut(trigger.target()).unwrap();
     actions
         .bind::<Move>()
@@ -37,10 +37,7 @@ fn player_binding(trigger: Trigger<Binding<Player>>, mut players: Query<&mut Act
         .to((KeyCode::KeyI, GamepadButton::Select));
 }
 
-fn inventory_binding(
-    trigger: Trigger<Binding<Inventory>>,
-    mut players: Query<&mut Actions<Inventory>>,
-) {
+fn bind_inventory(trigger: Trigger<Bind<Inventory>>, mut players: Query<&mut Actions<Inventory>>) {
     let mut actions = players.get_mut(trigger.target()).unwrap();
     actions
         .bind::<NavigateInventory>()

--- a/examples/keybinding_menu.rs
+++ b/examples/keybinding_menu.rs
@@ -369,7 +369,7 @@ fn apply(
         }
     }
 
-    commands.trigger(RebuildBindings);
+    commands.trigger(RebindAll);
 
     match settings.write(SETTINGS_PATH) {
         Ok(()) => info!("writing settings to '{SETTINGS_PATH}'"),

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -107,7 +107,7 @@ fn apply_movement(trigger: Trigger<Fired<Move>>, mut players: Query<&mut Transfo
 }
 
 fn update_gamepads(mut commands: Commands) {
-    commands.trigger(RebuildBindings);
+    commands.trigger(RebindAll);
 }
 
 /// Used as both input context and component.

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -8,7 +8,7 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .init_resource::<Gamepads>()
         .add_input_context::<Player>()
-        .add_observer(binding)
+        .add_observer(bind)
         .add_observer(apply_movement)
         .add_systems(Startup, spawn)
         .add_systems(
@@ -59,8 +59,8 @@ fn spawn(
     ));
 }
 
-fn binding(
-    trigger: Trigger<Binding<Player>>,
+fn bind(
+    trigger: Trigger<Bind<Player>>,
     gamepads: Query<Entity, With<Gamepad>>,
     mut players: Query<(&Player, &mut Actions<Player>)>,
 ) {

--- a/examples/simple_fly_cam.rs
+++ b/examples/simple_fly_cam.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<FlyCam>() // All contexts should be registered.
-        .add_observer(binding) // Add observer to setup bindings.
+        .add_observer(bind) // Add observer to setup bindings.
         .add_observer(apply_movement)
         .add_observer(capture_cursor)
         .add_observer(release_cursor)
@@ -50,10 +50,10 @@ fn setup(
     ));
 }
 
-// To define bindings for actions, write an observer for `Binding`.
+// To define bindings for actions, write an observer for `Bind`.
 // It's also possible to create bindings before the insertion,
 // but this way you can conveniently reload bindings when settings change.
-fn binding(trigger: Trigger<Binding<FlyCam>>, mut players: Query<&mut Actions<FlyCam>>) {
+fn bind(trigger: Trigger<Bind<FlyCam>>, mut players: Query<&mut Actions<FlyCam>>) {
     let mut actions = players.get_mut(trigger.target()).unwrap();
 
     // Bindings like WASD or sticks are very common,

--- a/src/action_instances.rs
+++ b/src/action_instances.rs
@@ -182,7 +182,7 @@ fn update<S: ScheduleLabel>(
 }
 
 fn rebuild<S: ScheduleLabel>(
-    _trigger: Trigger<RebuildBindings>,
+    _trigger: Trigger<RebindAll>,
     mut commands: Commands,
     mut reset_input: ResMut<ResetInput>,
     mut instances: ResMut<ActionInstances<S>>,
@@ -385,7 +385,7 @@ type RebuildFn = fn(
 /// Trigger that requests bindings creation of [`Actions`] for an entity.
 ///
 /// Can't be triggered by user. If you want to reload bindings, just re-insert
-/// the component or trigger [`RebuildBindings`].
+/// the component or trigger [`RebindAll`].
 #[derive(Event)]
 pub struct Bind<C: InputContext>(PhantomData<C>);
 
@@ -406,4 +406,4 @@ impl<C: InputContext> Bind<C> {
 /// This will also reset all actions to [`ActionState::None`]
 /// and trigger the corresponding events.
 #[derive(Event)]
-pub struct RebuildBindings;
+pub struct RebindAll;

--- a/src/action_instances.rs
+++ b/src/action_instances.rs
@@ -233,7 +233,7 @@ impl<S: ScheduleLabel> ActionInstances<S> {
             any::type_name::<C>(),
         );
 
-        commands.trigger_targets(Binding::<C>::new(), entity);
+        commands.trigger_targets(Bind::<C>::new(), entity);
 
         let instance = ActionsInstance::new::<C>(entity);
         match self.binary_search_by_key(&Reverse(C::PRIORITY), |inst| Reverse(inst.priority)) {
@@ -362,7 +362,7 @@ impl ActionsInstance {
             .expect("deinitialized instances should be previously removed");
 
         actions.reset(commands, reset_input, time, self.entity);
-        commands.trigger_targets(Binding::<C>::new(), self.entity);
+        commands.trigger_targets(Bind::<C>::new(), self.entity);
     }
 }
 
@@ -387,9 +387,9 @@ type RebuildFn = fn(
 /// Can't be triggered by user. If you want to reload bindings, just re-insert
 /// the component or trigger [`RebuildBindings`].
 #[derive(Event)]
-pub struct Binding<C: InputContext>(PhantomData<C>);
+pub struct Bind<C: InputContext>(PhantomData<C>);
 
-impl<C: InputContext> Binding<C> {
+impl<C: InputContext> Bind<C> {
     /// Creates a new instance.
     ///
     /// Not exposed to users to because we need to properly

--- a/src/input_modifier/clamp.rs
+++ b/src/input_modifier/clamp.rs
@@ -14,8 +14,8 @@ use crate::{action_map::ActionMap, prelude::*};
 /// use bevy::prelude::*;
 /// use bevy_enhanced_input::prelude::*;
 ///
-/// fn binding(
-///     trigger: Trigger<Binding<Ui>>,
+/// fn bind(
+///     trigger: Trigger<Bind<Ui>>,
 ///     mut ui: Query<&mut Actions<Ui>>,
 /// ) {
 ///     let mut actions = ui.get_mut(trigger.target()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ Similar to modifiers, you can also attach conditions to input tuples using [`Int
 It's convenient to define bindings in a single function that used every time you activate the context
 or reload your application settings.
 
-To achieve this, we provide a special [`Binding<C>`] event that triggers when you insert or replace
+To achieve this, we provide a special [`Bind<C>`] event that triggers when you insert or replace
 [`Actions<C>`] component. Just create an observer for it and define all your bindings there:
 
 ```
@@ -207,7 +207,7 @@ app.add_observer(bind_actions);
 
 /// Setups bindings for [`OnFoot`] context from application settings.
 fn bind_actions(
-    trigger: Trigger<Binding<OnFoot>>,
+    trigger: Trigger<Bind<OnFoot>>,
     settings: Res<AppSettings>,
     mut actions: Query<&mut Actions<OnFoot>>
 ) {
@@ -233,7 +233,7 @@ struct KeyboardSettings {
 ```
 
 We also provide a user-triggerable [`RebuildBindings`] event that resets bindings for all inserted
-[`Actions`] and also triggers [`Binding`] event for them.
+[`Actions`] and also triggers [`Bind`] event for them.
 
 ## Reacting on actions
 
@@ -347,7 +347,7 @@ pub mod prelude {
     pub use super::{
         EnhancedInputPlugin, EnhancedInputSystem,
         action_binding::{ActionBinding, MockSpan},
-        action_instances::{Binding, InputContextAppExt, RebuildBindings},
+        action_instances::{Bind, InputContextAppExt, RebuildBindings},
         action_map::{Action, ActionState},
         action_value::{ActionValue, ActionValueDim},
         actions::{Actions, InputContext},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ struct KeyboardSettings {
 # struct Jump;
 ```
 
-We also provide a user-triggerable [`RebuildBindings`] event that resets bindings for all inserted
+We also provide a user-triggerable [`RebindAll`] event that resets bindings for all inserted
 [`Actions`] and also triggers [`Bind`] event for them.
 
 ## Reacting on actions
@@ -347,7 +347,7 @@ pub mod prelude {
     pub use super::{
         EnhancedInputPlugin, EnhancedInputSystem,
         action_binding::{ActionBinding, MockSpan},
-        action_instances::{Bind, InputContextAppExt, RebuildBindings},
+        action_instances::{Bind, InputContextAppExt, RebindAll},
         action_map::{Action, ActionState},
         action_value::{ActionValue, ActionValueDim},
         actions::{Actions, InputContext},

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -16,8 +16,8 @@ use crate::prelude::*;
 /// use bevy::prelude::*;
 /// use bevy_enhanced_input::prelude::*;
 ///
-/// fn binding(
-///     trigger: Trigger<Binding<Player>>,
+/// fn bind(
+///     trigger: Trigger<Bind<Player>>,
 ///     settings: Res<KeyboardSettings>,
 ///     mut players: Query<&mut Actions<Player>>,
 /// ) {
@@ -122,8 +122,8 @@ impl<I: IntoBindings> IntoBindings for Cardinal<I> {
 /// use bevy::prelude::*;
 /// use bevy_enhanced_input::prelude::*;
 ///
-/// fn binding(
-///     trigger: Trigger<Binding<Player>>,
+/// fn bind(
+///     trigger: Trigger<Bind<Player>>,
 ///     settings: Res<GamepadSettings>,
 ///     mut players: Query<&mut Actions<Player>>,
 /// ) {

--- a/tests/accumulation.rs
+++ b/tests/accumulation.rs
@@ -7,7 +7,7 @@ fn max_abs() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -29,7 +29,7 @@ fn cumulative() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -50,7 +50,7 @@ fn cumulative() {
     );
 }
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<MaxAbs>().to(Cardinal::wasd_keys());
     actions.bind::<Cumulative>().to(Cardinal::arrow_keys());

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -7,7 +7,7 @@ fn explicit() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Player>::default()).id();
@@ -49,7 +49,7 @@ fn implicit() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Player>::default()).id();
@@ -118,7 +118,7 @@ fn blocker() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Player>::default()).id();
@@ -182,7 +182,7 @@ fn blocker() -> Result<()> {
     Ok(())
 }
 
-fn binding(trigger: Trigger<Binding<Player>>, mut actions: Query<&mut Actions<Player>>) {
+fn bind(trigger: Trigger<Bind<Player>>, mut actions: Query<&mut Actions<Player>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions
         .bind::<ReleaseAction>()

--- a/tests/consume_input.rs
+++ b/tests/consume_input.rs
@@ -7,7 +7,7 @@ fn consume() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(consume_only_binding)
+        .add_observer(bind_consume_only)
         .finish();
 
     let entity1 = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -39,7 +39,7 @@ fn passthrough() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(passthrough_only_binding)
+        .add_observer(bind_passthrough_only)
         .finish();
 
     let entity1 = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -71,7 +71,7 @@ fn consume_then_passthrough() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(consume_then_passthrough_binding)
+        .add_observer(bind_consume_then_passthrough)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -100,7 +100,7 @@ fn passthrough_then_consume() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(passthrough_then_consume_binding)
+        .add_observer(bind_passthrough_then_consume)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -125,7 +125,7 @@ fn modifiers() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(modifiers_binding)
+        .add_observer(bind_modifiers)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -155,21 +155,18 @@ fn modifiers() -> Result<()> {
     Ok(())
 }
 
-fn consume_only_binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind_consume_only(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Consume>().to(KEY);
 }
 
-fn passthrough_only_binding(
-    trigger: Trigger<Binding<Test>>,
-    mut actions: Query<&mut Actions<Test>>,
-) {
+fn bind_passthrough_only(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Passthrough>().to(KEY);
 }
 
-fn consume_then_passthrough_binding(
-    trigger: Trigger<Binding<Test>>,
+fn bind_consume_then_passthrough(
+    trigger: Trigger<Bind<Test>>,
     mut actions: Query<&mut Actions<Test>>,
 ) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
@@ -177,8 +174,8 @@ fn consume_then_passthrough_binding(
     actions.bind::<Passthrough>().to(KEY);
 }
 
-fn passthrough_then_consume_binding(
-    trigger: Trigger<Binding<Test>>,
+fn bind_passthrough_then_consume(
+    trigger: Trigger<Bind<Test>>,
     mut actions: Query<&mut Actions<Test>>,
 ) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
@@ -186,7 +183,7 @@ fn passthrough_then_consume_binding(
     actions.bind::<Consume>().to(KEY);
 }
 
-fn modifiers_binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind_modifiers(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<NoModifiers>().to(KEY);
     actions

--- a/tests/context_gamepad.rs
+++ b/tests/context_gamepad.rs
@@ -7,7 +7,7 @@ fn any() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<AnyGamepad>()
-        .add_observer(any_gamepad_binding)
+        .add_observer(bind_any_gamepad)
         .finish();
 
     let gamepad_entity1 = app.world_mut().spawn(Gamepad::default()).id();
@@ -50,7 +50,7 @@ fn by_id() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<SingleGamepad>()
-        .add_observer(single_gamepad_binding)
+        .add_observer(bind_single_gamepad)
         .finish();
 
     let gamepad_entity1 = app.world_mut().spawn(Gamepad::default()).id();
@@ -94,16 +94,16 @@ fn by_id() -> Result<()> {
     Ok(())
 }
 
-fn any_gamepad_binding(
-    trigger: Trigger<Binding<AnyGamepad>>,
+fn bind_any_gamepad(
+    trigger: Trigger<Bind<AnyGamepad>>,
     mut actions: Query<&mut Actions<AnyGamepad>>,
 ) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<TestAction>().to(TestAction::BUTTON);
 }
 
-fn single_gamepad_binding(
-    trigger: Trigger<Binding<SingleGamepad>>,
+fn bind_single_gamepad(
+    trigger: Trigger<Bind<SingleGamepad>>,
     mut actions: Query<(&mut Actions<SingleGamepad>, &mut SingleGamepad)>,
 ) {
     let (mut actions, gamepad) = actions.get_mut(trigger.target()).unwrap();

--- a/tests/dim.rs
+++ b/tests/dim.rs
@@ -7,7 +7,7 @@ fn bool() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -40,7 +40,7 @@ fn axis1d() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -73,7 +73,7 @@ fn axis2d() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -106,7 +106,7 @@ fn axis3d() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -134,7 +134,7 @@ fn axis3d() -> Result<()> {
     Ok(())
 }
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Bool>().to(Bool::KEY);
     actions.bind::<Axis1D>().to(Axis1D::KEY);

--- a/tests/fixed_timestep.rs
+++ b/tests/fixed_timestep.rs
@@ -10,7 +10,7 @@ fn once_in_two_frames() -> Result<()> {
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -51,7 +51,7 @@ fn twice_in_one_frame() -> Result<()> {
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -80,7 +80,7 @@ fn twice_in_one_frame() -> Result<()> {
     Ok(())
 }
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<TestAction>().to(TestAction::KEY);
 }

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -7,7 +7,7 @@ fn removal() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -33,7 +33,7 @@ fn rebuild() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -55,7 +55,7 @@ fn rebuild_all() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -84,7 +84,7 @@ fn rebuild_all() -> Result<()> {
     Ok(())
 }
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<TestAction>().to(TestAction::KEY);
 }

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -71,7 +71,7 @@ fn rebuild_all() -> Result<()> {
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     assert_eq!(actions.state::<TestAction>()?, ActionState::Fired);
 
-    app.world_mut().trigger(RebuildBindings);
+    app.world_mut().trigger(RebindAll);
     app.world_mut().flush();
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -7,7 +7,7 @@ fn keys() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -74,7 +74,7 @@ fn dpad() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let gamepad_entity = app.world_mut().spawn(Gamepad::default()).id();
@@ -112,7 +112,7 @@ fn sticks() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let gamepad_entity = app.world_mut().spawn(Gamepad::default()).id();
@@ -158,7 +158,7 @@ const RIGHT_DOWN: Vec3 = Vec3::new(1.0, -1.0, 0.0);
 const LEFT_DOWN: Vec3 = Vec3::new(-1.0, -1.0, 0.0);
 const LEFT_UP: Vec3 = Vec3::new(-1.0, 1.0, 0.0);
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<TestAction>().to((
         Cardinal::wasd_keys(),

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -8,8 +8,8 @@ fn prioritization() -> Result<()> {
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
         .add_input_context::<Second>()
-        .add_observer(first_binding)
-        .add_observer(second_binding)
+        .add_observer(bind_first)
+        .add_observer(bind_second)
         .finish();
 
     let entity = app
@@ -44,13 +44,13 @@ fn prioritization() -> Result<()> {
     Ok(())
 }
 
-fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {
+fn bind_first(trigger: Trigger<Bind<First>>, mut actions: Query<&mut Actions<First>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<FirstConsume>().to(CONSUME_KEY);
     actions.bind::<FirstPassthrough>().to(PASSTHROUGH_KEY);
 }
 
-fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Actions<Second>>) {
+fn bind_second(trigger: Trigger<Bind<Second>>, mut actions: Query<&mut Actions<Second>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<SecondConsume>().to(CONSUME_KEY);
     actions.bind::<SecondPassthrough>().to(PASSTHROUGH_KEY);

--- a/tests/require_reset.rs
+++ b/tests/require_reset.rs
@@ -8,8 +8,8 @@ fn layering() -> Result<()> {
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
         .add_input_context::<Second>()
-        .add_observer(first_binding)
-        .add_observer(second_binding)
+        .add_observer(bind_first)
+        .add_observer(bind_second)
         .finish();
 
     let entity = app
@@ -68,8 +68,8 @@ fn switching() -> Result<()> {
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
         .add_input_context::<Second>()
-        .add_observer(first_binding)
-        .add_observer(second_binding)
+        .add_observer(bind_first)
+        .add_observer(bind_second)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<First>::default()).id();
@@ -117,12 +117,12 @@ fn switching() -> Result<()> {
     Ok(())
 }
 
-fn first_binding(trigger: Trigger<Binding<First>>, mut actions: Query<&mut Actions<First>>) {
+fn bind_first(trigger: Trigger<Bind<First>>, mut actions: Query<&mut Actions<First>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<TestAction>().to(TestAction::KEY);
 }
 
-fn second_binding(trigger: Trigger<Binding<Second>>, mut actions: Query<&mut Actions<Second>>) {
+fn bind_second(trigger: Trigger<Bind<Second>>, mut actions: Query<&mut Actions<Second>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<TestAction>().to(TestAction::KEY);
 }

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -7,7 +7,7 @@ fn input_level() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -81,7 +81,7 @@ fn action_level() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -155,7 +155,7 @@ fn both_levels() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<Test>()
-        .add_observer(binding)
+        .add_observer(bind)
         .finish();
 
     let entity = app.world_mut().spawn(Actions::<Test>::default()).id();
@@ -224,7 +224,7 @@ fn both_levels() -> Result<()> {
     Ok(())
 }
 
-fn binding(trigger: Trigger<Binding<Test>>, mut actions: Query<&mut Actions<Test>>) {
+fn bind(trigger: Trigger<Bind<Test>>, mut actions: Query<&mut Actions<Test>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
 
     let down = Down::default();


### PR DESCRIPTION
Looks like Bevy is going for short names (`Trigger` -> `On`), and I think we should do the same. I like these names more 🙂

I’m also considering splitting `Bindings` from `Actions`, so it’s better to have distinctive names.