### PR TITLE
Make pull-based API more strongly typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make all data fields of `Action` public.
 - Return the strongly typed output of an action from `Actions::value`, similar to triggers.
 - Rename `ActionOutput::as_output` into `ActionOutput::unwrap_value`.
+- Rename `Action` into `UntypedAction`.
+- `Actions::get` now returns a typed `Action<A>`.
 
 ### Removed
 

--- a/src/input_context/action_binding.rs
+++ b/src/input_context/action_binding.rs
@@ -305,7 +305,7 @@ impl ActionBinding {
         &mut self,
         commands: &mut Commands,
         reader: &mut InputReader,
-        action_map: &mut TypeIdMap<Action>,
+        action_map: &mut TypeIdMap<UntypedAction>,
         time: &InputTime,
         entity: Entity,
     ) {
@@ -324,7 +324,7 @@ impl ActionBinding {
     pub(super) fn update_from_reader(
         &mut self,
         reader: &mut InputReader,
-        action_map: &mut TypeIdMap<Action>,
+        action_map: &mut TypeIdMap<UntypedAction>,
         time: &InputTime,
     ) -> (ActionState, ActionValue) {
         trace!("updating `{}` from input", self.action_name);

--- a/src/input_context/events.rs
+++ b/src/input_context/events.rs
@@ -292,7 +292,7 @@ mod tests {
         );
 
         let time = state.get(&world);
-        let mut action = Action::new::<TestAction>();
+        let mut action = UntypedAction::new::<TestAction>();
         action.state = initial_state;
         action.update(&time, target_state, true);
         action.trigger_events(&mut world.commands(), Entity::PLACEHOLDER);

--- a/src/input_context/input_action.rs
+++ b/src/input_context/input_action.rs
@@ -169,6 +169,7 @@ fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, entity: Entity,
 /// A strongly-typed version of [`Action`].
 ///
 /// Can be obtained from [`Actions::get`].
+#[derive(Clone, Copy, Debug)]
 pub struct Action<A: InputAction> {
     /// Current state.
     pub state: ActionState,

--- a/src/input_context/input_action.rs
+++ b/src/input_context/input_action.rs
@@ -8,9 +8,9 @@ use crate::prelude::*;
 
 /// Data associated with an [`InputAction`] marker.
 ///
-/// Stored inside [`Actions`].
+/// Type-erased version of [`Action`]. Stored inside [`Actions`].
 #[derive(Clone, Copy)]
-pub struct Action {
+pub struct UntypedAction {
     /// Current state.
     pub state: ActionState,
 
@@ -32,7 +32,7 @@ pub struct Action {
     trigger_events: fn(&Self, &mut Commands, Entity),
 }
 
-impl Action {
+impl UntypedAction {
     /// Creates a new instance associated with action `A`.
     ///
     /// [`Self::trigger_events`] will trigger events for `A`.
@@ -45,6 +45,16 @@ impl Action {
             elapsed_secs: 0.0,
             fired_secs: 0.0,
             trigger_events: Self::trigger_events_typed::<A>,
+        }
+    }
+
+    pub(super) fn typed<A: InputAction>(&self) -> Action<A> {
+        Action {
+            state: self.state,
+            events: self.events,
+            value: A::Output::unwrap_value(self.value),
+            elapsed_secs: self.elapsed_secs,
+            fired_secs: self.fired_secs,
         }
     }
 
@@ -154,6 +164,26 @@ fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, entity: Entity,
         any::type_name::<A>()
     );
     commands.trigger_targets(event, entity);
+}
+
+/// A strongly-typed version of [`Action`].
+///
+/// Can be obtained from [`Actions::get`].
+pub struct Action<A: InputAction> {
+    /// Current state.
+    pub state: ActionState,
+
+    /// Events triggered by a transition of [`Self::state`] since the last update.
+    pub events: ActionEvents,
+
+    /// Value since the last update.
+    pub value: A::Output,
+
+    /// Time the action was in [`ActionState::Ongoing`] and [`ActionState::Fired`] states.
+    pub elapsed_secs: f32,
+
+    /// Time the action was in [`ActionState::Fired`] state.
+    pub fired_secs: f32,
 }
 
 /// State for [`Action`].

--- a/src/input_context/input_condition.rs
+++ b/src/input_context/input_condition.rs
@@ -32,7 +32,7 @@ pub trait InputCondition: Sync + Send + Debug + 'static {
     /// `actions` is a state of other actions within the currently evaluating context.
     fn evaluate(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionState;

--- a/src/input_context/input_condition/block_by.rs
+++ b/src/input_context/input_condition/block_by.rs
@@ -34,7 +34,7 @@ impl<A: InputAction> Copy for BlockBy<A> {}
 impl<A: InputAction> InputCondition for BlockBy<A> {
     fn evaluate(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         _value: ActionValue,
     ) -> ActionState {
@@ -68,12 +68,12 @@ mod tests {
     #[test]
     fn block() {
         let mut condition = BlockBy::<TestAction>::default();
-        let mut action = Action::new::<TestAction>();
+        let mut action = UntypedAction::new::<TestAction>();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
         action.update(&time, ActionState::Fired, true);
-        let mut action_map = TypeIdMap::<Action>::default();
+        let mut action_map = TypeIdMap::<UntypedAction>::default();
         action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn missing_action() {
         let mut condition = BlockBy::<TestAction>::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/chord.rs
+++ b/src/input_context/input_condition/chord.rs
@@ -36,7 +36,7 @@ impl<A: InputAction> Copy for Chord<A> {}
 impl<A: InputAction> InputCondition for Chord<A> {
     fn evaluate(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         _value: ActionValue,
     ) -> ActionState {
@@ -70,12 +70,12 @@ mod tests {
     #[test]
     fn chord() {
         let mut condition = Chord::<TestAction>::default();
-        let mut action = Action::new::<TestAction>();
+        let mut action = UntypedAction::new::<TestAction>();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
         action.update(&time, ActionState::Fired, true);
-        let mut action_map = TypeIdMap::<Action>::default();
+        let mut action_map = TypeIdMap::<UntypedAction>::default();
         action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn missing_action() {
         let mut condition = Chord::<TestAction>::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/down.rs
+++ b/src/input_context/input_condition/down.rs
@@ -26,7 +26,7 @@ impl Default for Down {
 impl InputCondition for Down {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -46,7 +46,7 @@ mod tests {
     #[test]
     fn down() {
         let mut condition = Down::new(1.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/hold.rs
+++ b/src/input_context/input_condition/hold.rs
@@ -56,7 +56,7 @@ impl Hold {
 impl InputCondition for Hold {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn hold() {
         let mut condition = Hold::new(1.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn one_shot() {
         let mut hold = Hold::new(1.0).one_shot(true);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         world
             .resource_mut::<Time>()

--- a/src/input_context/input_condition/hold_and_release.rs
+++ b/src/input_context/input_condition/hold_and_release.rs
@@ -45,7 +45,7 @@ impl HoldAndRelease {
 impl InputCondition for HoldAndRelease {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn hold_and_release() {
         let mut condition = HoldAndRelease::new(1.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/press.rs
+++ b/src/input_context/input_condition/press.rs
@@ -32,7 +32,7 @@ impl Default for Press {
 impl InputCondition for Press {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn press() {
         let mut condition = Press::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/pulse.rs
+++ b/src/input_context/input_condition/pulse.rs
@@ -73,7 +73,7 @@ impl Pulse {
 impl InputCondition for Pulse {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn pulse() {
         let mut condition = Pulse::new(1.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -155,7 +155,7 @@ mod tests {
     #[test]
     fn not_trigger_on_start() {
         let mut condition = Pulse::new(1.0).trigger_on_start(false);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn trigger_limit() {
         let mut condition = Pulse::new(1.0).with_trigger_limit(1);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/release.rs
+++ b/src/input_context/input_condition/release.rs
@@ -31,7 +31,7 @@ impl Default for Release {
 impl InputCondition for Release {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -58,7 +58,7 @@ mod tests {
     #[test]
     fn release() {
         let mut condition = Release::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_condition/tap.rs
+++ b/src/input_context/input_condition/tap.rs
@@ -48,7 +48,7 @@ impl Tap {
 impl InputCondition for Tap {
     fn evaluate(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionState {
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn tap() {
         let mut condition = Tap::new(1.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier.rs
+++ b/src/input_context/input_modifier.rs
@@ -27,7 +27,7 @@ pub trait InputModifier: Sync + Send + Debug + 'static {
     /// Called each frame.
     fn apply(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionValue;

--- a/src/input_context/input_modifier/accumulate_by.rs
+++ b/src/input_context/input_modifier/accumulate_by.rs
@@ -33,7 +33,7 @@ impl<A: InputAction> Default for AccumulateBy<A> {
 impl<A: InputAction> InputModifier for AccumulateBy<A> {
     fn apply(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -65,12 +65,12 @@ mod tests {
     #[test]
     fn accumulation_active() {
         let mut modifier = AccumulateBy::<TestAction>::default();
-        let mut action = Action::new::<TestAction>();
+        let mut action = UntypedAction::new::<TestAction>();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
         action.update(&time, ActionState::Fired, true);
-        let mut action_map = TypeIdMap::<Action>::default();
+        let mut action_map = TypeIdMap::<UntypedAction>::default();
         action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
@@ -80,10 +80,10 @@ mod tests {
     #[test]
     fn accumulation_inactive() {
         let mut modifier = AccumulateBy::<TestAction>::default();
-        let action = Action::new::<TestAction>();
+        let action = UntypedAction::new::<TestAction>();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
-        let mut action_map = TypeIdMap::<Action>::default();
+        let mut action_map = TypeIdMap::<UntypedAction>::default();
         action_map.insert(TypeId::of::<TestAction>(), action);
 
         assert_eq!(modifier.apply(&action_map, &time, 1.0.into()), 1.0.into());
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn missing_action() {
         let mut modifier = AccumulateBy::<TestAction>::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier/clamp.rs
+++ b/src/input_context/input_modifier/clamp.rs
@@ -80,7 +80,7 @@ impl Clamp {
 impl InputModifier for Clamp {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn clamping() {
         let mut modifier = Clamp::splat(0.0, 1.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier/dead_zone.rs
+++ b/src/input_context/input_modifier/dead_zone.rs
@@ -66,7 +66,7 @@ impl Default for DeadZone {
 impl InputModifier for DeadZone {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn radial() {
         let mut modifier = DeadZone::new(DeadZoneKind::Radial);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn axial() {
         let mut modifier = DeadZone::new(DeadZoneKind::Axial);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier/delta_scale.rs
+++ b/src/input_context/input_modifier/delta_scale.rs
@@ -11,7 +11,7 @@ pub struct DeltaScale;
 impl InputModifier for DeltaScale {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -38,7 +38,7 @@ mod tests {
 
     #[test]
     fn scaling() {
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         world
             .resource_mut::<Time>()

--- a/src/input_context/input_modifier/exponential_curve.rs
+++ b/src/input_context/input_modifier/exponential_curve.rs
@@ -29,7 +29,7 @@ impl ExponentialCurve {
 impl InputModifier for ExponentialCurve {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn exp() {
         let mut modifier = ExponentialCurve::splat(2.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier/negate.rs
+++ b/src/input_context/input_modifier/negate.rs
@@ -71,7 +71,7 @@ impl Negate {
 impl InputModifier for Negate {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn x() {
         let mut modifier = Negate::x();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn y() {
         let mut modifier = Negate::y();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn z() {
         let mut modifier = Negate::z();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn all() {
         let mut modifier = Negate::all();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier/scale.rs
+++ b/src/input_context/input_modifier/scale.rs
@@ -29,7 +29,7 @@ impl Scale {
 impl InputModifier for Scale {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn scaling() {
         let mut modifier = Scale::splat(2.0);
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/input_modifier/smooth_nudge.rs
+++ b/src/input_context/input_modifier/smooth_nudge.rs
@@ -36,7 +36,7 @@ impl Default for SmoothNudge {
 impl InputModifier for SmoothNudge {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn lerp() {
         let mut modifier = SmoothNudge::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         world
             .resource_mut::<Time>()
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn bool_as_axis1d() {
         let mut modifier = SmoothNudge::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         world
             .resource_mut::<Time>()
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn snapping() {
         let mut modifier = SmoothNudge::default();
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (mut world, mut state) = input_time::init_world();
         world
             .resource_mut::<Time>()

--- a/src/input_context/input_modifier/swizzle_axis.rs
+++ b/src/input_context/input_modifier/swizzle_axis.rs
@@ -49,7 +49,7 @@ pub enum SwizzleAxis {
 impl InputModifier for SwizzleAxis {
     fn apply(
         &mut self,
-        _action_map: &TypeIdMap<Action>,
+        _action_map: &TypeIdMap<UntypedAction>,
         _time: &InputTime,
         value: ActionValue,
     ) -> ActionValue {
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn yxz() {
         let mut modifier = SwizzleAxis::YXZ;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn zyx() {
         let mut modifier = SwizzleAxis::ZYX;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn xzy() {
         let mut modifier = SwizzleAxis::XZY;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn yzx() {
         let mut modifier = SwizzleAxis::YZX;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn zxy() {
         let mut modifier = SwizzleAxis::ZXY;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn xxy() {
         let mut modifier = SwizzleAxis::XXY;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn yyx() {
         let mut modifier = SwizzleAxis::YYX;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -308,7 +308,7 @@ mod tests {
     #[test]
     fn xxz() {
         let mut modifier = SwizzleAxis::XXZ;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -337,7 +337,7 @@ mod tests {
     #[test]
     fn yyz() {
         let mut modifier = SwizzleAxis::YYZ;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn zzx() {
         let mut modifier = SwizzleAxis::ZZX;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn zzy() {
         let mut modifier = SwizzleAxis::ZZY;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn xxx() {
         let mut modifier = SwizzleAxis::XXX;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn yyy() {
         let mut modifier = SwizzleAxis::YYY;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn zzz() {
         let mut modifier = SwizzleAxis::ZZZ;
-        let action_map = TypeIdMap::<Action>::default();
+        let action_map = TypeIdMap::<UntypedAction>::default();
         let (world, mut state) = input_time::init_world();
         let time = state.get(&world);
 

--- a/src/input_context/trigger_tracker.rs
+++ b/src/input_context/trigger_tracker.rs
@@ -34,7 +34,7 @@ impl TriggerTracker {
 
     pub(super) fn apply_modifiers(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         modifiers: &mut [Box<dyn InputModifier>],
     ) {
@@ -51,7 +51,7 @@ impl TriggerTracker {
 
     pub(super) fn apply_conditions(
         &mut self,
-        action_map: &TypeIdMap<Action>,
+        action_map: &TypeIdMap<UntypedAction>,
         time: &InputTime,
         conditions: &mut [Box<dyn InputCondition>],
     ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ pub mod prelude {
             action_binding::{ActionBinding, MockSpan},
             actions::Actions,
             events::*,
-            input_action::{Accumulation, Action, ActionState, InputAction},
+            input_action::{Accumulation, Action, ActionState, InputAction, UntypedAction},
             input_binding::{BindingBuilder, InputBinding, IntoBindings},
             input_condition::{
                 ConditionKind, InputCondition, block_by::*, chord::*, down::*, hold::*,

--- a/tests/condition_kind.rs
+++ b/tests/condition_kind.rs
@@ -16,7 +16,7 @@ fn explicit() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Explicit>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     app.world_mut()
@@ -27,7 +27,7 @@ fn explicit() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Explicit>()?;
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -38,7 +38,7 @@ fn explicit() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Explicit>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     Ok(())
@@ -58,12 +58,12 @@ fn implicit() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Implicit>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     app.world_mut()
@@ -74,12 +74,12 @@ fn implicit() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Ongoing);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Implicit>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::Ongoing);
 
     app.world_mut()
@@ -90,24 +90,24 @@ fn implicit() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::Fired);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Implicit>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::Fired);
 
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Implicit>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     Ok(())
@@ -127,12 +127,12 @@ fn blocker() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Blocker>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
@@ -143,12 +143,12 @@ fn blocker() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Ongoing);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Blocker>()?;
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -159,24 +159,24 @@ fn blocker() -> Result<()> {
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::Fired);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Blocker>()?;
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::None);
 
     app.update();
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<ReleaseAction>()?;
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
 
     let actions = app.world().get::<Actions<Player>>(entity).unwrap();
     let action = actions.get::<Blocker>()?;
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
 
     Ok(())

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -19,7 +19,7 @@ fn updates() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
     assert_eq!(action.events, ActionEvents::FIRED | ActionEvents::STARTED);
 
@@ -27,7 +27,7 @@ fn updates() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
     assert_eq!(action.events, ActionEvents::COMPLETED);
 }
@@ -51,7 +51,7 @@ fn duration() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
     assert_eq!(action.events, ActionEvents::FIRED | ActionEvents::STARTED);
 
@@ -59,7 +59,7 @@ fn duration() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
     assert_eq!(action.events, ActionEvents::FIRED);
 
@@ -67,7 +67,7 @@ fn duration() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
     assert_eq!(action.events, ActionEvents::COMPLETED);
 }
@@ -87,7 +87,7 @@ fn manual() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
     assert_eq!(action.events, ActionEvents::FIRED | ActionEvents::STARTED);
 
@@ -95,7 +95,7 @@ fn manual() {
 
     let mut actions = app.world_mut().get_mut::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, true.into());
+    assert!(action.value);
     assert_eq!(action.state, ActionState::Fired);
     assert_eq!(action.events, ActionEvents::FIRED);
 
@@ -105,7 +105,7 @@ fn manual() {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<TestAction>().unwrap();
-    assert_eq!(action.value, false.into());
+    assert!(!action.value);
     assert_eq!(action.state, ActionState::None);
     assert_eq!(action.events, ActionEvents::COMPLETED);
 }

--- a/tests/state_and_value_merge.rs
+++ b/tests/state_and_value_merge.rs
@@ -22,7 +22,7 @@ fn input_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<InputLevel>()?;
-    assert_eq!(action.value, (Vec2::Y * 2.0).into());
+    assert_eq!(action.value, Vec2::Y * 2.0);
     assert_eq!(action.state, ActionState::Ongoing);
 
     app.world_mut()
@@ -33,7 +33,7 @@ fn input_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<InputLevel>()?;
-    assert_eq!(action.value, (Vec2::Y * 2.0).into());
+    assert_eq!(action.value, Vec2::Y * 2.0);
     assert_eq!(action.state, ActionState::Fired);
 
     let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
@@ -44,7 +44,7 @@ fn input_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<InputLevel>()?;
-    assert_eq!(action.value, Vec2::NEG_Y.into());
+    assert_eq!(action.value, Vec2::NEG_Y);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -55,7 +55,7 @@ fn input_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<InputLevel>()?;
-    assert_eq!(action.value, Vec2::Y.into());
+    assert_eq!(action.value, Vec2::Y);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -66,7 +66,7 @@ fn input_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<InputLevel>()?;
-    assert_eq!(action.value, Vec2::ZERO.into());
+    assert_eq!(action.value, Vec2::ZERO);
     assert_eq!(
         action.state,
         ActionState::None,
@@ -96,7 +96,7 @@ fn action_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<ActionLevel>()?;
-    assert_eq!(action.value, (Vec2::NEG_Y * 2.0).into());
+    assert_eq!(action.value, Vec2::NEG_Y * 2.0);
     assert_eq!(action.state, ActionState::Ongoing);
 
     app.world_mut()
@@ -107,7 +107,7 @@ fn action_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<ActionLevel>()?;
-    assert_eq!(action.value, (Vec2::NEG_Y * 2.0).into());
+    assert_eq!(action.value, Vec2::NEG_Y * 2.0);
     assert_eq!(action.state, ActionState::Fired);
 
     let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
@@ -118,7 +118,7 @@ fn action_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<ActionLevel>()?;
-    assert_eq!(action.value, (Vec2::NEG_Y * 2.0).into());
+    assert_eq!(action.value, Vec2::NEG_Y * 2.0);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -129,7 +129,7 @@ fn action_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<ActionLevel>()?;
-    assert_eq!(action.value, (Vec2::NEG_Y * 4.0).into());
+    assert_eq!(action.value, Vec2::NEG_Y * 4.0);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -140,7 +140,7 @@ fn action_level() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<ActionLevel>()?;
-    assert_eq!(action.value, (Vec2::NEG_Y * 4.0).into());
+    assert_eq!(action.value, Vec2::NEG_Y * 4.0);
     assert_eq!(
         action.state,
         ActionState::None,
@@ -170,7 +170,7 @@ fn both_levels() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<BothLevels>()?;
-    assert_eq!(action.value, (Vec2::Y * 2.0).into());
+    assert_eq!(action.value, Vec2::Y * 2.0);
     assert_eq!(action.state, ActionState::Ongoing);
 
     app.world_mut()
@@ -181,7 +181,7 @@ fn both_levels() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<BothLevels>()?;
-    assert_eq!(action.value, (Vec2::Y * 2.0).into());
+    assert_eq!(action.value, Vec2::Y * 2.0);
     assert_eq!(action.state, ActionState::Fired);
 
     let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
@@ -192,7 +192,7 @@ fn both_levels() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<BothLevels>()?;
-    assert_eq!(action.value, Vec2::NEG_Y.into());
+    assert_eq!(action.value, Vec2::NEG_Y);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -203,7 +203,7 @@ fn both_levels() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<BothLevels>()?;
-    assert_eq!(action.value, Vec2::Y.into());
+    assert_eq!(action.value, Vec2::Y);
     assert_eq!(action.state, ActionState::Fired);
 
     app.world_mut()
@@ -214,7 +214,7 @@ fn both_levels() -> Result<()> {
 
     let actions = app.world().get::<Actions<Test>>(entity).unwrap();
     let action = actions.get::<BothLevels>()?;
-    assert_eq!(action.value, Vec2::Y.into());
+    assert_eq!(action.value, Vec2::Y);
     assert_eq!(
         action.state,
         ActionState::None,


### PR DESCRIPTION
We already return the exact action's output type from `Actions::value`, but `Actions::get` still returns an `Action` that holds an `ActionValue`.

Renamed `Action` to `UntypedAction` and introduced a new `Action` type that is generic and holds the action's output type. It can be constructed from an `UntypedAction`. This allows returning a strongly typed action from `Actions::get`.