### PR TITLE
Derive `Clone` and `Copy` manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Action<A>` now implements `Clone` and `Copy` for any `A`.
+
 ## [0.13.0] - 2025-06-19
 
 ### Added

--- a/src/input_context/input_action.rs
+++ b/src/input_context/input_action.rs
@@ -169,7 +169,7 @@ fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, entity: Entity,
 /// A strongly-typed version of [`Action`].
 ///
 /// Can be obtained from [`Actions::get`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct Action<A: InputAction> {
     /// Current state.
     pub state: ActionState,
@@ -186,6 +186,14 @@ pub struct Action<A: InputAction> {
     /// Time the action was in [`ActionState::Fired`] state.
     pub fired_secs: f32,
 }
+
+impl<A: InputAction> Clone for Action<A> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<A: InputAction> Copy for Action<A> {}
 
 /// State for [`Action`].
 ///


### PR DESCRIPTION
Otherwise it's derived only for actions that implement `Copy` and `Clone` which is not always the case.