### PR TITLE
Updates for networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Action<A>` now implements `Clone` and `Copy` for any `A`.
+- `ActionEvents` now implements `Serialize` and `Deserialize`.
+- `BEIEnhancedSystem` has been split between `BEIEnhancedSet::Update` (read new inputs from the `InputReader` and update the `Actions` components)
+ and `BEIEnhancedSet::Trigger` (trigger the events corresponding to how the `Actions` components changed)
+- Most of the `Actions<C>` functionalities have been moved to an untyped struct `UntypedActions`. `Actions<C>` derefs to `UntypedActions` so you
+don't have to change any call site.
 
 ## [0.13.0] - 2025-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Action<A>` now implements `Clone` and `Copy` for any `A`.
 - `ActionEvents` now implements `Serialize` and `Deserialize`.
-- `BEIEnhancedSystem` has been split between `BEIEnhancedSet::Update` (read new inputs from the `InputReader` and update the `Actions` components)
- and `BEIEnhancedSet::Trigger` (trigger the events corresponding to how the `Actions` components changed)
+- `EnhancedInputSystem` has been split between `EnhancedInputSet::Update` (read new inputs from the `InputReader` and update the `Actions` components)
+ and `EnhancedInputSet::Trigger` (trigger the events corresponding to how the `Actions` components changed)
 - Most of the `Actions<C>` functionalities have been moved to an untyped struct `UntypedActions`. `Actions<C>` derefs to `UntypedActions` so you
 don't have to change any call site.
 

--- a/src/input_context.rs
+++ b/src/input_context.rs
@@ -403,7 +403,7 @@ impl ActionsInstance {
         actions: &mut Query<FilteredEntityMut>,
     ) {
         trace!(
-            "updating input context `{}` on `{}`",
+            "triggering input context `{}` on `{}`",
             any::type_name::<C>(),
             self.entity
         );

--- a/src/input_context.rs
+++ b/src/input_context.rs
@@ -26,7 +26,11 @@ use bevy::{
 };
 use log::{debug, trace};
 
-use crate::{input_reader::{InputReader, ResetInput}, prelude::*, EnhancedInputSet};
+use crate::{
+    EnhancedInputSet,
+    input_reader::{InputReader, ResetInput},
+    prelude::*,
+};
 
 /// An extension trait for [`App`] to assign input to components.
 pub trait InputContextAppExt {
@@ -128,7 +132,7 @@ impl ScheduleContexts {
         )
             .build_state(app.world_mut())
             .build_system(update::<S>);
-        
+
         let trigger = (
             ParamBuilder,
             ParamBuilder,
@@ -160,12 +164,18 @@ impl ScheduleContexts {
             .build_any_system(rebuild::<S>);
 
         app.init_resource::<ActionInstances<S>>()
-            .configure_sets(S::default(), (EnhancedInputSet::Update, EnhancedInputSet::Trigger).chain())
+            .configure_sets(
+                S::default(),
+                (EnhancedInputSet::Update, EnhancedInputSet::Trigger).chain(),
+            )
             .add_observer(rebuild)
-            .add_systems(S::default(), (
-                update.in_set(EnhancedInputSet::Update),
-                trigger.in_set(EnhancedInputSet::Trigger)
-            ));
+            .add_systems(
+                S::default(),
+                (
+                    update.in_set(EnhancedInputSet::Update),
+                    trigger.in_set(EnhancedInputSet::Trigger),
+                ),
+            );
     }
 }
 
@@ -244,7 +254,7 @@ impl<S: ScheduleLabel> ActionInstances<S> {
             instance.update(reader, time, actions);
         }
     }
-    
+
     pub(crate) fn trigger(
         &mut self,
         commands: &mut Commands,
@@ -349,13 +359,9 @@ impl ActionsInstance {
     ) {
         (self.update)(self, reader, time, actions);
     }
-    
+
     /// Calls [`Self::trigger_typed`] for `C` that was associated in [`Self::new`].
-    fn trigger(
-        &self,
-        commands: &mut Commands,
-        actions: &mut Query<FilteredEntityMut>,
-    ) {
+    fn trigger(&self, commands: &mut Commands, actions: &mut Query<FilteredEntityMut>) {
         (self.trigger)(self, commands, actions);
     }
 
@@ -390,7 +396,7 @@ impl ActionsInstance {
 
         actions.update(reader, time, self.entity);
     }
-    
+
     fn trigger_typed<C: InputContext>(
         &self,
         commands: &mut Commands,
@@ -435,18 +441,9 @@ impl ActionsInstance {
     }
 }
 
-type UpdateFn = fn(
-    &ActionsInstance,
-    &mut InputReader,
-    &InputTime,
-    &mut Query<FilteredEntityMut>,
-);
+type UpdateFn = fn(&ActionsInstance, &mut InputReader, &InputTime, &mut Query<FilteredEntityMut>);
 
-type TriggerFn = fn(
-    &ActionsInstance,
-    &mut Commands,
-    &mut Query<FilteredEntityMut>,
-);
+type TriggerFn = fn(&ActionsInstance, &mut Commands, &mut Query<FilteredEntityMut>);
 
 type RebuildFn =
     fn(&ActionsInstance, &mut Commands, &mut ResetInput, &InputTime, &mut Query<FilteredEntityMut>);

--- a/src/input_context/action_binding.rs
+++ b/src/input_context/action_binding.rs
@@ -303,11 +303,9 @@ impl ActionBinding {
 
     pub(super) fn update(
         &mut self,
-        commands: &mut Commands,
         reader: &mut InputReader,
         action_map: &mut TypeIdMap<UntypedAction>,
         time: &InputTime,
-        entity: Entity,
     ) {
         let (state, value) = self
             .update_from_mock(time.delta())
@@ -318,7 +316,6 @@ impl ActionBinding {
             .expect("actions and bindings should have matching type IDs");
 
         action.update(time, state, value);
-        action.trigger_events(commands, entity);
     }
 
     pub(super) fn update_from_reader(
@@ -416,6 +413,18 @@ impl ActionBinding {
         }
 
         Some((state, value))
+    }
+    
+    pub(super) fn trigger(
+        &mut self,
+        commands: &mut Commands,
+        action_map: &mut TypeIdMap<UntypedAction>,
+        entity: Entity,
+    ) {
+        let action = action_map
+            .get_mut(&self.type_id)
+            .expect("actions and bindings should have matching type IDs");
+        action.trigger_events(commands, entity);
     }
 
     pub(super) fn type_id(&self) -> TypeId {

--- a/src/input_context/action_binding.rs
+++ b/src/input_context/action_binding.rs
@@ -287,7 +287,7 @@ impl ActionBinding {
         self
     }
 
-    /// Type-erased version for [`Actions::mock`].
+    /// Type-erased version for [`UntypedActions::mock`].
     pub fn mock(&mut self, state: ActionState, value: ActionValue, span: MockSpan) {
         debug!(
             "mocking `{}` with `{state:?}` and `{value:?}` for `{span:?}`",
@@ -457,7 +457,7 @@ struct ActionMock {
 
 /// Specifies how long a mock input should remain active.
 ///
-/// See also [`Actions::mock`].
+/// See also [`UntypedActions::mock`].
 #[derive(Clone, Copy, Debug)]
 pub enum MockSpan {
     /// Mock for a fixed number of context evaluations.

--- a/src/input_context/action_binding.rs
+++ b/src/input_context/action_binding.rs
@@ -288,7 +288,7 @@ impl ActionBinding {
     }
 
     /// Type-erased version for [`Actions::mock`].
-    pub(super) fn mock(&mut self, state: ActionState, value: ActionValue, span: MockSpan) {
+    pub fn mock(&mut self, state: ActionState, value: ActionValue, span: MockSpan) {
         debug!(
             "mocking `{}` with `{state:?}` and `{value:?}` for `{span:?}`",
             self.action_name,
@@ -414,7 +414,7 @@ impl ActionBinding {
 
         Some((state, value))
     }
-    
+
     pub(super) fn trigger(
         &mut self,
         commands: &mut Commands,

--- a/src/input_context/action_binding.rs
+++ b/src/input_context/action_binding.rs
@@ -288,7 +288,7 @@ impl ActionBinding {
     }
 
     /// Type-erased version for [`UntypedActions::mock`].
-    pub fn mock(&mut self, state: ActionState, value: ActionValue, span: MockSpan) {
+    pub(super) fn mock(&mut self, state: ActionState, value: ActionValue, span: MockSpan) {
         debug!(
             "mocking `{}` with `{state:?}` and `{value:?}` for `{span:?}`",
             self.action_name,

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -106,7 +106,6 @@ impl<C: InputContext> Actions<C> {
         get_or_create_binding_untyped::<A>(&mut self.bindings, &mut self.action_map)
     }
 
-
     /// Returns bindings for each action in their evaluation order.
     pub fn bindings(&self) -> &[ActionBinding] {
         &self.bindings
@@ -135,10 +134,6 @@ impl<C: InputContext> Actions<C> {
     /// Returns a type-erased action for the given type ID if it exists.
     pub fn get_mut_by_id(&mut self, type_id: TypeId) -> Option<&mut UntypedAction> {
         self.action_map.get_mut(&type_id)
-    }
-
-    pub fn entry_by_id(&mut self, type_id: TypeId) -> Entry<TypeId, UntypedAction, NoOpHash> {
-        self.action_map.entry(type_id)
     }
 
     /// Returns the associated data for action `A` if it exists.

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -1,14 +1,15 @@
 use alloc::vec::Vec;
-use bevy::{platform::collections::hash_map::Entry, prelude::*, utils::TypeIdMap};
-use core::ops::{Deref, DerefMut};
 use core::{
     any::{self, TypeId},
     cmp::Reverse,
     error::Error,
     fmt::{self, Debug, Display, Formatter},
     marker::PhantomData,
+    ops::{Deref, DerefMut},
 };
 use log::debug;
+
+use bevy::{platform::collections::hash_map::Entry, prelude::*, utils::TypeIdMap};
 
 use crate::{
     input_reader::{InputReader, ResetInput},

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -31,33 +31,6 @@ pub struct Actions<C: InputContext> {
     marker: PhantomData<C>,
 }
 
-pub struct UntypedActions<'a> {
-    gamepad: &'a mut GamepadDevice,
-    bindings: &'a mut Vec<ActionBinding>,
-    action_map: &'a mut TypeIdMap<UntypedAction>,
-    sort_required: &'a mut bool,
-}
-
-impl<'a> UntypedActions<'a> {
-    fn get_or_create_binding<A: InputAction>(
-        &mut self,
-    ) -> &mut ActionBinding {
-        let type_id = TypeId::of::<A>();
-        match self.action_map.entry(type_id) {
-            Entry::Occupied(_entry) => self.bindings
-                .iter_mut()
-                .find(|binding| binding.type_id() == type_id)
-                .expect("actions and bindings should have matching type IDs"),
-            Entry::Vacant(entry) => {
-                entry.insert(UntypedAction::new::<A>());
-                self.bindings.push(ActionBinding::new::<A>());
-                self.bindings.last_mut().unwrap()
-            }
-        }
-    }
-
-}
-
 impl<C: InputContext> Actions<C> {
     /// Associates context with gamepad.
     ///
@@ -219,7 +192,7 @@ impl<C: InputContext> Actions<C> {
             binding.update(reader, &mut self.action_map, time);
         }
     }
-    
+
     pub(crate) fn trigger(
         &mut self,
         commands: &mut Commands,

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -28,7 +28,6 @@ pub struct Actions<C: InputContext> {
     marker: PhantomData<C>,
 }
 
-
 /// Data associated with an [`InputContext`] marker.
 ///
 /// Type-erased version of [`Actions`] stored inside it.

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -43,7 +43,7 @@ impl<C: InputContext> DerefMut for Actions<C> {
 
 /// Data associated with an [`InputContext`] marker.
 ///
-/// Type-erased version of [`Actions`]. Stored inside [`Actions`].
+/// Type-erased version of [`Actions`] stored inside it.
 #[derive(Default)]
 pub struct UntypedActions {
     gamepad: GamepadDevice,

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -5,7 +5,6 @@ use core::{
     error::Error,
     fmt::{self, Debug, Display, Formatter},
     marker::PhantomData,
-    ops::{Deref, DerefMut},
 };
 use log::debug;
 
@@ -22,25 +21,13 @@ use crate::{
 /// Data for each bound action represented by [`Action`].
 ///
 /// Actions are evaluated and trigger [`events`](super::events) only when this component exists on an entity.
-#[derive(Component)]
+#[derive(Component, Deref, DerefMut)]
 pub struct Actions<C: InputContext> {
+    #[deref]
     actions: UntypedActions,
     marker: PhantomData<C>,
 }
 
-impl<C: InputContext> Deref for Actions<C> {
-    type Target = UntypedActions;
-
-    fn deref(&self) -> &Self::Target {
-        &self.actions
-    }
-}
-
-impl<C: InputContext> DerefMut for Actions<C> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.actions
-    }
-}
 
 /// Data associated with an [`InputContext`] marker.
 ///

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -25,8 +25,8 @@ use crate::{
 #[derive(Component)]
 pub struct Actions<C: InputContext> {
     gamepad: GamepadDevice,
-    bindings: Vec<ActionBinding>,
-    action_map: TypeIdMap<UntypedAction>,
+    pub bindings: Vec<ActionBinding>,
+    pub action_map: TypeIdMap<UntypedAction>,
     sort_required: bool,
     marker: PhantomData<C>,
 }
@@ -163,11 +163,11 @@ impl<C: InputContext> Actions<C> {
     pub fn get_mut_by_id(&mut self, type_id: TypeId) -> Option<&mut UntypedAction> {
         self.action_map.get_mut(&type_id)
     }
-    
+
     pub fn entry_by_id(&mut self, type_id: TypeId) -> Entry<TypeId, UntypedAction, NoOpHash> {
         self.action_map.entry(type_id)
     }
-    
+
     /// Returns the associated data for action `A` if it exists.
     ///
     /// Use [`Self::bind`] to associate an action with the context.

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -6,9 +6,9 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
     marker::PhantomData,
 };
-use log::debug;
 
 use bevy::{platform::collections::hash_map::Entry, prelude::*, utils::TypeIdMap};
+use log::debug;
 
 use crate::{
     input_reader::{InputReader, ResetInput},

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -201,7 +201,6 @@ impl<C: InputContext> Actions<C> {
 
     pub(crate) fn update(
         &mut self,
-        commands: &mut Commands,
         reader: &mut InputReader,
         time: &InputTime,
         entity: Entity,
@@ -217,7 +216,26 @@ impl<C: InputContext> Actions<C> {
 
         reader.set_gamepad(self.gamepad);
         for binding in &mut self.bindings {
-            binding.update(commands, reader, &mut self.action_map, time, entity);
+            binding.update(reader, &mut self.action_map, time);
+        }
+    }
+    
+    pub(crate) fn trigger(
+        &mut self,
+        commands: &mut Commands,
+        entity: Entity,
+    ) {
+        if self.sort_required {
+            debug!(
+                "sorting actions of `{}` on `{entity}`",
+                any::type_name::<C>()
+            );
+            self.bindings.sort_by_key(|b| Reverse(b.max_mod_keys()));
+            self.sort_required = false;
+        }
+
+        for binding in &mut self.bindings {
+            binding.trigger(commands, &mut self.action_map, entity);
         }
     }
 

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use bevy::platform::hash::NoOpHash;
 use bevy::{platform::collections::hash_map::Entry, prelude::*, utils::TypeIdMap};
 use core::ops::{Deref, DerefMut};
 use core::{

--- a/src/input_context/actions.rs
+++ b/src/input_context/actions.rs
@@ -17,7 +17,7 @@ use crate::{
 
 /// Component that stores actions with their bindings for a specific [`InputContext`].
 ///
-/// Bindings represented by [`ActionBinding`] and can be added to specific action using [`Self::bind`].
+/// Bindings represented by [`ActionBinding`] and can be added to specific action using [`UntypedActions::bind`].
 /// Data for each bound action represented by [`Action`].
 ///
 /// Actions are evaluated and trigger [`events`](super::events) only when this component exists on an entity.

--- a/src/input_context/events.rs
+++ b/src/input_context/events.rs
@@ -5,7 +5,6 @@ use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
-use serde::{Deserialize, Serialize};
 
 bitflags! {
     /// Bitset with events triggered by updating [`ActionState`] for an action.

--- a/src/input_context/events.rs
+++ b/src/input_context/events.rs
@@ -1,8 +1,10 @@
 use core::fmt::Debug;
 
-use crate::prelude::*;
 use bevy::prelude::*;
 use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 
 bitflags! {

--- a/src/input_context/events.rs
+++ b/src/input_context/events.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use bevy::prelude::*;
 use bitflags::bitflags;
-
+use serde::{Deserialize, Serialize};
 use crate::prelude::*;
 
 bitflags! {
@@ -28,7 +28,7 @@ bitflags! {
     ///
     /// The meaning of each kind depends on the assigned [`InputCondition`]s. The events are
     /// fired in the action evaluation order.
-    #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+    #[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
     pub struct ActionEvents: u8 {
         /// Corresponds to [`Started`].
         const STARTED = 0b00000001;

--- a/src/input_context/events.rs
+++ b/src/input_context/events.rs
@@ -1,9 +1,9 @@
 use core::fmt::Debug;
 
+use crate::prelude::*;
 use bevy::prelude::*;
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
-use crate::prelude::*;
 
 bitflags! {
     /// Bitset with events triggered by updating [`ActionState`] for an action.

--- a/src/input_context/input_action.rs
+++ b/src/input_context/input_action.rs
@@ -168,7 +168,7 @@ fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, entity: Entity,
 
 /// A strongly-typed version of [`Action`].
 ///
-/// Can be obtained from [`Actions::get`].
+/// Can be obtained from [`UntypedActions::get`].
 #[derive(Debug)]
 pub struct Action<A: InputAction> {
     /// Current state.
@@ -218,7 +218,7 @@ pub enum ActionState {
 
 /// Marker for a gameplay-related action.
 ///
-/// Needs to be bound to actions using [`Actions::bind`].
+/// Needs to be bound to actions using [`UntypedActions::bind`].
 ///
 /// To implement the trait you can use the [`InputAction`](bevy_enhanced_input_macros::InputAction)
 /// derive to reduce boilerplate:

--- a/src/input_reader.rs
+++ b/src/input_reader.rs
@@ -224,7 +224,7 @@ impl InputReader<'_, '_> {
 /// use bevy_enhanced_input::prelude::*;
 ///
 /// # let mut app = App::new();
-/// app.add_systems(PreUpdate, disable_mouse.before(EnhancedInputSystem));
+/// app.add_systems(PreUpdate, disable_mouse.before(EnhancedInputSet::Update));
 ///
 /// fn disable_mouse(
 ///     mut action_sources: ResMut<ActionSources>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,8 +404,8 @@ impl Plugin for EnhancedInputPlugin {
 /// Runs in each registered [`InputContext::Schedule`].
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 pub enum EnhancedInputSet {
-    /// Update the state of the input contexts using the InputReaders
+    /// Updates the state of the input contexts from inputs and mocks.
     Update,
-    /// Trigger events
+    /// Triggers events.
     Trigger,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ time, bindings must be assigned at runtime. They're stored inside the [`Actions<
 context. Contexts becomes active only when its component exists on an entity. You can attach multiple [`Actions<C>`]
 components to a single entity.
 
-To bind actions, use [`Actions::bind`] followed by one or more [`ActionBinding::to`] calls to define inputs. You can pass any
+To bind actions, use [`UntypedActions::bind`] followed by one or more [`ActionBinding::to`] calls to define inputs. You can pass any
 input type that implements [`IntoBindings`], including tuples for multiple inputs (similar to [`App::add_systems`] in Bevy).
 All assigned inputs will be treated as "any of". See [`ActionBinding::to`] for details.
 
@@ -284,7 +284,7 @@ The event system is highly flexible. For example, you can use the [`Hold`] condi
 
 ### Pull-style
 
-You can also query for [`Actions`] within a system. Use [`Actions::get<A>`] to retrieve an [`Action`], from which you can obtain the
+You can also query for [`Actions`] within a system. Use [`UntypedActions::get<A>`] to retrieve an [`Action`], from which you can obtain the
 current value, state, or triggered events for this tick as [`ActionEvents`] bitset.
 
 ```
@@ -346,7 +346,7 @@ pub mod prelude {
         input_context::{
             Bind, InputContext, InputContextAppExt, RebindAll,
             action_binding::{ActionBinding, MockSpan},
-            actions::Actions,
+            actions::{Actions, UntypedActions},
             events::*,
             input_action::{Accumulation, Action, ActionState, InputAction, UntypedAction},
             input_binding::{BindingBuilder, InputBinding, IntoBindings},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub mod input_time;
 
 pub mod prelude {
     pub use super::{
-        EnhancedInputPlugin, EnhancedInputSystem,
+        EnhancedInputPlugin, EnhancedInputSet,
         action_value::{ActionValue, ActionValueDim},
         input::{GamepadDevice, Input, InputModKeys, ModKeys},
         input_context::{
@@ -376,7 +376,7 @@ use prelude::*;
 
 /// Initializes contexts and feeds inputs to them.
 ///
-/// See also [`EnhancedInputSystem`].
+/// See also [`EnhancedInputSet`].
 pub struct EnhancedInputPlugin;
 
 impl Plugin for EnhancedInputPlugin {
@@ -384,7 +384,7 @@ impl Plugin for EnhancedInputPlugin {
         app.init_resource::<ContextRegistry>()
             .init_resource::<ResetInput>()
             .init_resource::<ActionSources>()
-            .configure_sets(PreUpdate, EnhancedInputSystem.after(InputSystem));
+            .configure_sets(PreUpdate, EnhancedInputSet::Update.after(InputSystem));
     }
 
     fn finish(&self, app: &mut App) {
@@ -403,4 +403,9 @@ impl Plugin for EnhancedInputPlugin {
 ///
 /// Runs in each registered [`InputContext::Schedule`].
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
-pub struct EnhancedInputSystem;
+pub enum EnhancedInputSet {
+    /// Update the state of the input contexts using the InputReaders
+    Update,
+    /// Trigger events
+    Trigger,
+}


### PR DESCRIPTION
- On the receiver (server), i need to be able to bind an action to a context in an untyped manner. This change allows me to register a function pointer for each `InputAction`, instead of for each `InputAction X InputContext`
- I need to have a bit more flexibility while ordering systems, I would like to be able to schedule systems between `BEI::Update` and `BEI::Trigger`, so I added a new system set for Trigger
- I decided to network the ActionEvents as well, so I need a Serialize/Desreialize implementation on them