### PR TITLE
Consume inputs between contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Action<A>` now implements `Clone` and `Copy` for any `A`.
 - `ActionEvents` now implements `Serialize` and `Deserialize`.
-- Split `EnhancedInputSystem` into `EnhancedInputSet::Update` (reads new inputs from the `InputReader` and updates the `Actions` components) and `EnhancedInputSet::Trigger` (triggers the events corresponding to how the `Actions` components changed).
+- Split `EnhancedInputSystem` into `EnhancedInputSet::UpdateReader` (resets consumed inputs and updates reset inputs for `InputReader`), `EnhancedInputSet::UpdateContexts` (reads new inputs from the `InputReader` and updates the `Actions` components), `EnhancedInputSet::Trigger` (triggers the events corresponding to how the `Actions` components changed).
 - Move most of the `Actions<C>` functionality to an untyped struct `UntypedActions`. `Actions<C>` derefs to `UntypedActions`, so you don't have to change any call sites.
+- Consume inputs between contexts.
 
 ## [0.13.0] - 2025-06-19
 

--- a/src/input_context.rs
+++ b/src/input_context.rs
@@ -166,13 +166,13 @@ impl ScheduleContexts {
         app.init_resource::<ActionInstances<S>>()
             .configure_sets(
                 S::default(),
-                (EnhancedInputSet::Update, EnhancedInputSet::Trigger).chain(),
+                (EnhancedInputSet::UpdateContexts, EnhancedInputSet::Trigger).chain(),
             )
             .add_observer(rebuild)
             .add_systems(
                 S::default(),
                 (
-                    update.in_set(EnhancedInputSet::Update),
+                    update.in_set(EnhancedInputSet::UpdateContexts),
                     trigger.in_set(EnhancedInputSet::Trigger),
                 ),
             );
@@ -210,7 +210,6 @@ fn update<S: ScheduleLabel>(
     mut instances: ResMut<ActionInstances<S>>,
     mut actions: Query<FilteredEntityMut>,
 ) {
-    reader.update_state();
     instances.update(&mut reader, &time, &mut actions);
 }
 
@@ -518,8 +517,9 @@ pub trait InputContext: Send + Sync + 'static {
 
     /// Determines the evaluation order of [`Actions<Self>`].
     ///
-    /// Used to control how contexts are layered since some [`InputAction`]s may consume inputs.
+    /// Used to control how contexts are layered, as some [`InputAction`]s may consume inputs.
     ///
-    /// Ordering is global. Contexts with a higher priority are evaluated first.
+    /// The ordering applies per schedule: contexts in schedules that run earlier are evaluated first.
+    /// Within the same schedule, contexts with a higher priority are evaluated first.
     const PRIORITY: usize = 0;
 }

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -1,9 +1,9 @@
-use bevy::{input::InputPlugin, prelude::*};
+use bevy::{input::InputPlugin, prelude::*, time::TimeUpdateStrategy};
 use bevy_enhanced_input::prelude::*;
 use test_log::test;
 
 #[test]
-fn prioritization() -> Result<()> {
+fn same_schedule() -> Result<()> {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
         .add_input_context::<First>()
@@ -44,6 +44,66 @@ fn prioritization() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn different_schedules() -> Result<()> {
+    let time_step = Time::<Fixed>::default().timestep() / 2;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+        .insert_resource(TimeUpdateStrategy::ManualDuration(time_step))
+        .add_input_context::<First>()
+        .add_input_context::<FixedSchedule>()
+        .add_observer(bind::<First>)
+        .add_observer(bind::<FixedSchedule>)
+        .finish();
+
+    let entity = app
+        .world_mut()
+        .spawn((
+            Actions::<First>::default(),
+            Actions::<FixedSchedule>::default(),
+        ))
+        .id();
+
+    let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+    keys.press(Consume::KEY);
+    keys.press(Passthrough::KEY);
+
+    for frame in 0..2 {
+        app.update();
+
+        let actions = app.world().get::<Actions<First>>(entity).unwrap();
+        assert_eq!(actions.state::<Consume>()?, ActionState::Fired);
+        assert_eq!(actions.state::<Passthrough>()?, ActionState::Fired);
+
+        let fixed_actions = app.world().get::<Actions<FixedSchedule>>(entity).unwrap();
+        assert_eq!(fixed_actions.state::<Consume>()?, ActionState::None);
+        assert_eq!(
+            fixed_actions.state::<Passthrough>()?,
+            ActionState::None,
+            "shouldn't fire on frame {frame} because the schedule hasn't run yet"
+        );
+    }
+
+    for frame in 2..4 {
+        app.update();
+
+        let actions = app.world().get::<Actions<First>>(entity).unwrap();
+        assert_eq!(actions.state::<Consume>()?, ActionState::Fired);
+        assert_eq!(actions.state::<Passthrough>()?, ActionState::Fired);
+
+        let fixed_actions = app.world().get::<Actions<FixedSchedule>>(entity).unwrap();
+        assert_eq!(
+            fixed_actions.state::<Consume>()?,
+            ActionState::None,
+            "shouldn't fire on frame {frame} because of the schedule evaluation order"
+        );
+        assert_eq!(fixed_actions.state::<Passthrough>()?, ActionState::Fired);
+    }
+
+    Ok(())
+}
+
 fn bind<C: InputContext>(trigger: Trigger<Bind<C>>, mut actions: Query<&mut Actions<C>>) {
     let mut actions = actions.get_mut(trigger.target()).unwrap();
     actions.bind::<Consume>().to(Consume::KEY);
@@ -56,6 +116,10 @@ struct First;
 
 #[derive(InputContext)]
 struct Second;
+
+#[derive(InputContext)]
+#[input_context(schedule = FixedPreUpdate, priority = 3)]
+struct FixedSchedule;
 
 #[derive(Debug, InputAction)]
 #[input_action(output = bool, consume_input = true)]


### PR DESCRIPTION
I noticed that input consumption was local to the context's schedule, while reset inputs were global. Now both are global, as this is more expected and convenient.