### PR TITLE
Make the mocking work without `InputPlugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Binding::AnyKey` to assign any button.
 - `Cooldown` input condition.
 
+### Changed
+
+- Mocking can be used without `InputPlugin`.
+
 ## [0.17.0] - 2025-08-18
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,9 @@ You can also mock actions using the [`ActionMock`] component. When it's present 
 the [`ActionState`] and [`ActionValue`] for the specified [`MockSpan`] duration. During this time, all bindings for this action will be ignored.
 For more details, see the [`ActionMock`] documentation.
 
+If you only need mocking, you can disable [`InputPlugin`](bevy::input::InputPlugin) entirely. However, `bevy_input` is a required dependency
+because we use its input types.
+
 ## Reacting on actions
 
 Up to this point, we've only defined actions and contexts but haven't reacted to them yet.

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -1,13 +1,13 @@
 use core::time::Duration;
 
-use bevy::{input::InputPlugin, prelude::*, time::TimeUpdateStrategy};
+use bevy::{prelude::*, time::TimeUpdateStrategy};
 use bevy_enhanced_input::prelude::*;
 use test_log::test;
 
 #[test]
 fn updates() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, EnhancedInputPlugin))
         .add_input_context::<TestContext>()
         .finish();
 
@@ -43,7 +43,7 @@ fn updates() {
 #[test]
 fn duration() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, EnhancedInputPlugin))
         .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(1)))
         .add_input_context::<TestContext>()
         .finish();
@@ -90,7 +90,7 @@ fn duration() {
 #[test]
 fn manual() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, InputPlugin, EnhancedInputPlugin))
+    app.add_plugins((MinimalPlugins, EnhancedInputPlugin))
         .add_input_context::<TestContext>()
         .finish();
 


### PR DESCRIPTION
Asked in https://github.com/simgine/bevy_enhanced_input/issues/164#issuecomment-3222452205.
~Requires #181. Will rebase to the latest once #181 merged.~ Rebased.