### PR TITLE
Simplify README to avoid duplication with lib.rs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A powerful observer-based input manager for [Bevy](https://bevyengine.org), allowing you to bind keys and other inputs to in-game actions.
 
-The design of this crate was inspired by [Unreal Engine Enhanced Input](https://dev.epicgames.com/documentation/en-us/unreal-engine/enhanced-input-in-unreal-engine). Thanks!
+The design of this crate was inspired by [Unreal Engine Enhanced Input](https://dev.epicgames.com/documentation/en-us/unreal-engine/enhanced-input-in-unreal-engine) plugin.
 
 ## Getting Started
 


### PR DESCRIPTION
## Problem

The current README has three major problems:

1. It throws a lot of concepts at the reader very quickly, without adequate treatment.
2. It's quite redundant with the very good crate docs.
3. It won't stick around post upstreaming.

## Solution

Most projects deduplicate this by using the README as the crate docs, but I didn't want to include the meta-information in the crate docs.

Instead, I've stripped it down and made it very clear that users are expected to read the crate docs.