### PR TITLE
Rename simple_fly_cam example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check out the [crate docs](https://docs.rs/bevy_enhanced_input) for an overview 
 and all of the information needed to quickly integrate this into your game.
 
 The examples in the repo are also a useful to learn from.
-[simple_fly_cam.rs](examples/simple_fly_cam.rs) should be a good starting point.
+[basic_action_management.rs](examples/basic_action_management.rs) should be a good starting point.
 
 ## Getting help
 

--- a/examples/basic_action_management.rs
+++ b/examples/basic_action_management.rs
@@ -1,4 +1,8 @@
-//! Simple fly camera with a single context.
+//! Demonstrates basic mapping between inputs and actions.
+//!
+//! This example uses a simple fly camera with a single context
+//! to demonstrate how to set up actions, define keybinds and respond to actions
+//! to modify the state of your application.
 
 use core::f32::consts::{FRAC_PI_2, FRAC_PI_8};
 


### PR DESCRIPTION
## Problem

1. If a beginner jumps straight to the examples it is unclear where they should start.
2. The naming of this example focuses on the wrong details: the pedagogical point of this example is to teach basic usage, not to teach how to setup a fly cam.

## Solution

1. Rename the example and references to it.
2. Improve the module docs for the example to explain why it exists.