### PR TITLE
feat: add Toggle condition

### DIFF
--- a/src/condition.rs
+++ b/src/condition.rs
@@ -62,6 +62,7 @@ pub mod press;
 pub mod pulse;
 pub mod release;
 pub mod tap;
+pub mod toggle;
 
 use core::fmt::Debug;
 

--- a/src/condition/toggle.rs
+++ b/src/condition/toggle.rs
@@ -1,0 +1,116 @@
+use bevy::prelude::*;
+
+use super::DEFAULT_ACTUATION;
+use crate::prelude::*;
+
+/// Returns [`ActionState::Fired`] when toggled on, [`ActionState::None`] when toggled off.
+///
+/// The toggle state flips each time the input transitions from non-actuated to actuated.
+/// This is useful for actions that should remain "on" after the player triggers them,
+/// and turn "off" when triggered again.
+///
+/// For example, if the player presses `F` you can use a toggle to make the `SelectingFireTarget`
+/// action remain "on", and then when they press `F` again the action turns "off".
+#[derive(Component, Reflect, Debug, Clone, Copy)]
+pub struct Toggle {
+    /// Trigger threshold.
+    pub actuation: f32,
+    /// Current toggle state (on/off).
+    pub toggled: bool,
+    actuated: bool,
+}
+
+impl Toggle {
+    #[must_use]
+    pub const fn new(actuation: f32) -> Self {
+        Self {
+            actuation,
+            toggled: false,
+            actuated: false,
+        }
+    }
+}
+
+impl Default for Toggle {
+    fn default() -> Self {
+        Self::new(DEFAULT_ACTUATION)
+    }
+}
+
+impl InputCondition for Toggle {
+    fn evaluate(
+        &mut self,
+        _actions: &ActionsQuery,
+        _time: &ContextTime,
+        value: ActionValue,
+    ) -> ActionState {
+        let previously_actuated = self.actuated;
+        self.actuated = value.is_actuated(self.actuation);
+
+        if self.actuated && !previously_actuated {
+            self.toggled = !self.toggled;
+        }
+
+        if self.toggled {
+            ActionState::Fired
+        } else {
+            ActionState::None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context;
+
+    #[test]
+    fn toggle() {
+        let (world, mut state) = context::init_world();
+        let (time, actions) = state.get(&world);
+
+        let mut condition = Toggle::default();
+
+        // Initially not actuated, should be None
+        assert_eq!(
+            condition.evaluate(&actions, &time, 0.0.into()),
+            ActionState::None
+        );
+
+        // First actuation toggles on -> Fired
+        assert_eq!(
+            condition.evaluate(&actions, &time, 1.0.into()),
+            ActionState::Fired,
+        );
+
+        // Continued actuation should maintain Fired
+        assert_eq!(
+            condition.evaluate(&actions, &time, 1.0.into()),
+            ActionState::Fired,
+        );
+
+        // Release (still toggled on) should maintain Fired
+        assert_eq!(
+            condition.evaluate(&actions, &time, 0.0.into()),
+            ActionState::Fired,
+        );
+
+        // Second actuation toggles off -> None
+        assert_eq!(
+            condition.evaluate(&actions, &time, 1.0.into()),
+            ActionState::None,
+        );
+
+        // Continued non-actuation should maintain None
+        assert_eq!(
+            condition.evaluate(&actions, &time, 0.0.into()),
+            ActionState::None,
+        );
+
+        // Third actuation toggles on again -> Fired
+        assert_eq!(
+            condition.evaluate(&actions, &time, 1.0.into()),
+            ActionState::Fired,
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ pub mod prelude {
         condition::{
             ConditionKind, InputCondition, block_by::*, chord::*, combo::*, cooldown::*, down::*,
             fns::InputConditionAppExt, hold::*, hold_and_release::*, press::*, pulse::*,
-            release::*, tap::*,
+            release::*, tap::*, toggle::*,
         },
         context::{
             ActionsQuery, ContextActivity, ContextPriority, GamepadDevice, InputContextAppExt,
@@ -402,7 +402,7 @@ use context::{
     input_reader::{self, ConsumedInputs, PendingBindings},
 };
 use modifier::fns::ModifierRegistry;
-use prelude::{Press, Release, *};
+use prelude::{Press, Release, Toggle, *};
 
 /// Initializes contexts and feeds inputs to them.
 ///
@@ -428,6 +428,7 @@ impl Plugin for EnhancedInputPlugin {
             .add_input_condition::<Release>()
             .add_input_condition::<Tap>()
             .add_input_condition::<Cooldown>()
+            .add_input_condition::<Toggle>()
             .add_input_modifier::<AccumulateBy>()
             .add_input_modifier::<Clamp>()
             .add_input_modifier::<DeadZone>()


### PR DESCRIPTION
## Summary
Adds a `Toggle` condition that allows actions to remain "on" after being triggered, turning "off" when triggered again.

This is useful for actions that should persist after the player triggers them. For example, if the player presses `F` you can use a toggle to make the `SelectingFireTarget` action remain "on", and then when they press `F` again the action turns "off".

Fixes #291

## Changes
- Add `Toggle` condition implementation in `src/condition/toggle.rs`
- Register `Toggle` in the condition module exports
- Register `Toggle` with the input condition system in `EnhancedInputPlugin`
- Include unit tests for toggle behavior

## Implementation Details
The `Toggle` condition tracks:
- `actuation`: The trigger threshold (default: 0.5)
- `toggled`: Current toggle state (on/off)
- `actuated`: Internal state tracking previous actuation

The toggle state flips each time the input transitions from non-actuated to actuated. When toggled on, it returns `ActionState::Fired`; when toggled off, it returns `ActionState::None`.

Reference implementation: https://gist.github.com/mgi388/da68cb3e8fe42ee54326f9bb381a1966

## Testing
- [x] cargo check passes
- [x] cargo test passes (98 tests including new toggle test)
- [x] Toggle behavior works as expected:
  - Initially not actuated -> None
  - First actuation toggles on -> Fired
  - Continued actuation maintains -> Fired
  - Release (while toggled on) maintains -> Fired
  - Second actuation toggles off -> None
  - Third actuation toggles on again -> Fired

## AI Transparency
This PR was created with the assistance of AI (Claude by Anthropic) for code generation and review.