### PR TITLE
Use a fixed timestep in the `character_controller` example

### DIFF
--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -19,8 +19,14 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_systems(Startup, setup)
+        .init_resource::<DidFixedUpdateRunThisFrame>()
+        .add_systems(PreUpdate, reset_fixed_update_flag)
+        .add_systems(FixedPreUpdate, set_fixed_update_flag)
         .add_systems(FixedUpdate, calculate_physics)
-        .add_systems(RunFixedMainLoop, clear_input)
+        .add_systems(
+            RunFixedMainLoop,
+            clear_input.run_if(did_fixed_update_run_this_frame),
+        )
         .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_movement)
         .add_observer(apply_jump)
@@ -141,4 +147,20 @@ struct Jump;
 struct AccumulatedInput {
     movement: f32,
     jump: bool,
+}
+
+// Fixed timestep boilerplate
+#[derive(Resource, Deref, DerefMut, Default)]
+struct DidFixedUpdateRunThisFrame(bool);
+
+fn reset_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
+    flag.0 = false;
+}
+
+fn set_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
+    flag.0 = true;
+}
+
+fn did_fixed_update_run_this_frame(flag: Res<DidFixedUpdateRunThisFrame>) -> bool {
+    flag.0
 }

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -19,14 +19,11 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_systems(Startup, setup)
-        .init_resource::<DidFixedUpdateRunThisFrame>()
-        .add_systems(PreUpdate, reset_fixed_update_flag)
-        .add_systems(FixedPreUpdate, set_fixed_update_flag)
+        .init_resource::<FixedUpdateRan>()
+        .add_systems(PreUpdate, reset_fixed_update_ran)
+        .add_systems(FixedPreUpdate, set_fixed_update_ran)
         .add_systems(FixedUpdate, calculate_physics)
-        .add_systems(
-            RunFixedMainLoop,
-            clear_input.run_if(did_fixed_update_run_this_frame),
-        )
+        .add_systems(RunFixedMainLoop, clear_input.run_if(fixed_update_ran))
         .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_movement)
         .add_observer(apply_jump)
@@ -151,16 +148,16 @@ struct AccumulatedInput {
 
 // Fixed timestep boilerplate
 #[derive(Resource, Deref, DerefMut, Default)]
-struct DidFixedUpdateRunThisFrame(bool);
+struct FixedUpdateRan(bool);
 
-fn reset_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
-    flag.0 = false;
+fn reset_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
+    **ran = false;
 }
 
-fn set_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
-    flag.0 = true;
+fn set_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
+    **ran = true;
 }
 
-fn did_fixed_update_run_this_frame(flag: Res<DidFixedUpdateRunThisFrame>) -> bool {
-    flag.0
+fn fixed_update_ran(ran: Res<FixedUpdateRan>) -> bool {
+    **ran
 }

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -1,8 +1,8 @@
 //! Demonstrates how to create a simple platforming 2D character controller
 //! using actions with both keyboard and gamepad controls.
 //!
-//! Input is accumulated and applied to physics in a fixed timestep, as
-//! recommended in [this Bevy example](https://bevy.org/examples/movement/physics-in-fixed-timestep/)
+//! For kinematic character controllers, input should be accumulated and applied
+//! to physics in a fixed timestep as recommended in [this Bevy example](https://bevy.org/examples/movement/physics-in-fixed-timestep/)
 //! and as used in [bevy_ahoy](https://github.com/janhohenheim/bevy_ahoy).
 
 use bevy::prelude::*;
@@ -103,7 +103,7 @@ fn calculate_physics(
     fixed_time: Res<Time<Fixed>>,
     mut players: Query<(&mut Transform, &mut PlayerPhysics)>,
 ) {
-    for (mut transform, mut physics) in players.iter_mut() {
+    for (mut transform, mut physics) in &mut players {
         physics.velocity.y -= GRAVITY * fixed_time.delta_secs();
         transform.translation.y += physics.velocity.y * fixed_time.delta_secs();
         transform.translation.x += physics.velocity.x * fixed_time.delta_secs();

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -21,7 +21,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, calculate_physics)
         .add_systems(RunFixedMainLoop, clear_input)
-        .add_systems(FixedPostUpdate, run_character_controller)
+        .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_movement)
         .add_observer(apply_jump)
         .run();
@@ -70,28 +70,23 @@ fn setup(
     ));
 }
 
-fn apply_movement(
-    movement: On<Fire<Movement>>,
-    mut accumulated_inputs: Query<&mut AccumulatedInput>,
-) {
-    if let Ok(mut accumulated_inputs) = accumulated_inputs.get_mut(movement.context) {
-        accumulated_inputs.movement = movement.value;
+fn apply_movement(movement: On<Fire<Movement>>, mut inputs: Query<&mut AccumulatedInput>) {
+    let mut accumulated_inputs = inputs.get_mut(movement.context).unwrap();
+    accumulated_inputs.movement = movement.value;
+}
+
+fn apply_jump(jump: On<Fire<Jump>>, mut inputs: Query<&mut AccumulatedInput>) {
+    let mut accumulated_inputs = inputs.get_mut(jump.context).unwrap();
+    accumulated_inputs.jump = true;
+}
+
+fn clear_input(mut inputs: Query<&mut AccumulatedInput>) {
+    for mut inputs in &mut inputs {
+        *inputs = Default::default();
     }
 }
 
-fn apply_jump(jump: On<Fire<Jump>>, mut accumulated_inputs: Query<&mut AccumulatedInput>) {
-    if let Ok(mut accumulated_inputs) = accumulated_inputs.get_mut(jump.context) {
-        accumulated_inputs.jump = true;
-    }
-}
-
-fn clear_input(mut accumulated_inputs: Query<&mut AccumulatedInput>) {
-    for mut accumulated_input in &mut accumulated_inputs {
-        *accumulated_input = Default::default();
-    }
-}
-
-fn run_character_controller(players: Query<(&mut PlayerPhysics, &AccumulatedInput)>) {
+fn apply_input(players: Query<(&mut PlayerPhysics, &AccumulatedInput)>) {
     for (mut physics, input) in players {
         physics.velocity.x = input.movement;
         if input.jump && physics.is_grounded {
@@ -103,9 +98,9 @@ fn run_character_controller(players: Query<(&mut PlayerPhysics, &AccumulatedInpu
 
 fn calculate_physics(
     fixed_time: Res<Time<Fixed>>,
-    mut query: Query<(&mut Transform, &mut PlayerPhysics)>,
+    mut players: Query<(&mut Transform, &mut PlayerPhysics)>,
 ) {
-    for (mut transform, mut physics) in query.iter_mut() {
+    for (mut transform, mut physics) in players.iter_mut() {
         physics.velocity.y -= GRAVITY * fixed_time.delta_secs();
         transform.translation.y += physics.velocity.y * fixed_time.delta_secs();
         transform.translation.x += physics.velocity.x * fixed_time.delta_secs();

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -1,5 +1,9 @@
 //! Demonstrates how to create a simple platforming 2D character controller
 //! using actions with both keyboard and gamepad controls.
+//!
+//! Input is accumulated in and applied to physics in a fixed timestep, as
+//! recommended in [this Bevy example](https://bevy.org/examples/movement/physics-in-fixed-timestep/)
+//! and as used in [bevy_ahoy](https://github.com/janhohenheim/bevy_ahoy).
 
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
@@ -15,7 +19,9 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_systems(Startup, setup)
-        .add_systems(Update, calculate_physics)
+        .add_systems(FixedUpdate, calculate_physics)
+        .add_systems(RunFixedMainLoop, clear_input)
+        .add_systems(FixedPostUpdate, run_character_controller)
         .add_observer(apply_movement)
         .add_observer(apply_jump)
         .run();
@@ -41,6 +47,7 @@ fn setup(
         MeshMaterial2d(materials.add(Color::srgb(1.0, 0.0, 0.5))),
         Transform::from_translation(Vec3::Y * (GROUND_LEVEL + 500.0)),
         PlayerPhysics::default(),
+        AccumulatedInput::default(),
         actions!(Player[
             (
                 Action::<Movement>::new(),
@@ -63,17 +70,34 @@ fn setup(
     ));
 }
 
-fn apply_movement(movement: On<Fire<Movement>>, mut query: Query<&mut PlayerPhysics>) {
-    let mut physics = query.get_mut(movement.context).unwrap();
-    physics.velocity.x = movement.value;
+fn apply_movement(
+    movement: On<Fire<Movement>>,
+    mut accumulated_inputs: Query<&mut AccumulatedInput>,
+) {
+    if let Ok(mut accumulated_inputs) = accumulated_inputs.get_mut(movement.context) {
+        accumulated_inputs.movement = movement.value;
+    }
 }
 
-fn apply_jump(jump: On<Fire<Jump>>, mut query: Query<&mut PlayerPhysics>) {
-    let mut physics = query.get_mut(jump.context).unwrap();
-    if physics.is_grounded {
-        // Jump only if on the ground.
-        physics.velocity.y = JUMP_VELOCITY;
-        physics.is_grounded = false;
+fn apply_jump(jump: On<Fire<Jump>>, mut accumulated_inputs: Query<&mut AccumulatedInput>) {
+    if let Ok(mut accumulated_inputs) = accumulated_inputs.get_mut(jump.context) {
+        accumulated_inputs.jump = true;
+    }
+}
+
+fn clear_input(mut accumulated_inputs: Query<&mut AccumulatedInput>) {
+    for mut accumulated_input in &mut accumulated_inputs {
+        *accumulated_input = Default::default();
+    }
+}
+
+fn run_character_controller(players: Query<(&mut PlayerPhysics, &AccumulatedInput)>) {
+    for (mut physics, input) in players {
+        physics.velocity.x = input.movement;
+        if input.jump && physics.is_grounded {
+            physics.velocity.y = JUMP_VELOCITY;
+            physics.is_grounded = false;
+        }
     }
 }
 
@@ -113,3 +137,10 @@ struct Movement;
 #[derive(Debug, InputAction)]
 #[action_output(bool)]
 struct Jump;
+
+/// Accumulated input since the last fixed update.
+#[derive(Component, Default)]
+struct AccumulatedInput {
+    movement: f32,
+    jump: bool,
+}

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to create a simple platforming 2D character controller
 //! using actions with both keyboard and gamepad controls.
 //!
-//! Input is accumulated in and applied to physics in a fixed timestep, as
+//! Input is accumulated and applied to physics in a fixed timestep, as
 //! recommended in [this Bevy example](https://bevy.org/examples/movement/physics-in-fixed-timestep/)
 //! and as used in [bevy_ahoy](https://github.com/janhohenheim/bevy_ahoy).
 

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -101,11 +101,14 @@ fn run_character_controller(players: Query<(&mut PlayerPhysics, &AccumulatedInpu
     }
 }
 
-fn calculate_physics(time: Res<Time>, mut query: Query<(&mut Transform, &mut PlayerPhysics)>) {
+fn calculate_physics(
+    fixed_time: Res<Time<Fixed>>,
+    mut query: Query<(&mut Transform, &mut PlayerPhysics)>,
+) {
     for (mut transform, mut physics) in query.iter_mut() {
-        physics.velocity.y -= GRAVITY * time.delta_secs();
-        transform.translation.y += physics.velocity.y * time.delta_secs();
-        transform.translation.x += physics.velocity.x * time.delta_secs();
+        physics.velocity.y -= GRAVITY * fixed_time.delta_secs();
+        transform.translation.y += physics.velocity.y * fixed_time.delta_secs();
+        transform.translation.x += physics.velocity.x * fixed_time.delta_secs();
 
         // Prevent moving off screen.
         const MAX_X: f32 = GROUND_WIDTH / 2.0 - PLAYER.x / 2.0;

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -23,9 +23,15 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
+        .init_resource::<DidFixedUpdateRunThisFrame>()
+        .add_systems(PreUpdate, reset_fixed_update_flag)
+        .add_systems(FixedPreUpdate, set_fixed_update_flag)
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, (calculate_physics, update_gamepads))
-        .add_systems(RunFixedMainLoop, clear_input)
+        .add_systems(
+            RunFixedMainLoop,
+            clear_input.run_if(did_fixed_update_run_this_frame),
+        )
         .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_roll)
         .add_observer(apply_kick)
@@ -273,4 +279,20 @@ struct ArmKick;
 struct AccumulatedInput {
     roll: Vec2,
     kick: Option<Vec2>,
+}
+
+// Fixed timestep boilerplate
+#[derive(Resource, Deref, DerefMut, Default)]
+struct DidFixedUpdateRunThisFrame(bool);
+
+fn reset_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
+    flag.0 = false;
+}
+
+fn set_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
+    flag.0 = true;
+}
+
+fn did_fixed_update_run_this_frame(flag: Res<DidFixedUpdateRunThisFrame>) -> bool {
+    flag.0
 }

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -24,7 +24,9 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_systems(Startup, setup)
-        .add_systems(Update, (calculate_physics, update_gamepads))
+        .add_systems(FixedUpdate, (calculate_physics, update_gamepads))
+        .add_systems(RunFixedMainLoop, clear_input)
+        .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_roll)
         .add_observer(apply_kick)
         .run();
@@ -147,6 +149,7 @@ fn player_bundle(
         player,
         GamepadDevice::from(gamepad),
         PlayerPhysics::default(),
+        AccumulatedInput::default(),
         mesh.into(),
         material.into(),
         transform,
@@ -183,18 +186,33 @@ fn player_bundle(
     )
 }
 
-fn apply_roll(roll: On<Fire<Roll>>, mut physics: Query<&mut PlayerPhysics>) {
-    let mut physics = physics.get_mut(roll.context).unwrap();
-    physics.velocity += roll.value;
+fn apply_roll(roll: On<Fire<Roll>>, mut input: Query<&mut AccumulatedInput>) {
+    let mut input = input.get_mut(roll.context).unwrap();
+    input.roll = roll.value;
 }
 
-fn apply_kick(kick: On<Fire<Kick>>, mut physics: Query<&mut PlayerPhysics>) {
-    let mut physics = physics.get_mut(kick.context).unwrap();
-    // Normalize the input to treat vectors that are barely inside the threshold
-    // the same way as a vector along the edge.
-    let dir = kick.value.normalize();
+fn apply_kick(kick: On<Fire<Kick>>, mut input: Query<&mut AccumulatedInput>) {
+    let mut input = input.get_mut(kick.context).unwrap();
+    input.kick = Some(kick.value);
+}
 
-    physics.velocity = dir * KICK_IMPULSE;
+fn clear_input(mut inputs: Query<&mut AccumulatedInput>) {
+    for mut inputs in &mut inputs {
+        *inputs = Default::default();
+    }
+}
+
+fn apply_input(players: Query<(&mut PlayerPhysics, &AccumulatedInput)>) {
+    for (mut physics, input) in players {
+        physics.velocity += input.roll;
+
+        if let Some(kick) = input.kick {
+            // Normalize the input to treat vectors that are barely inside the threshold
+            // the same way as a vector along the edge.
+            let dir = kick.normalize();
+            physics.velocity = dir * KICK_IMPULSE;
+        }
+    }
 }
 
 fn calculate_physics(time: Res<Time>, players: Query<(&mut Transform, &mut PlayerPhysics)>) {
@@ -250,3 +268,9 @@ struct Kick;
 #[derive(InputAction)]
 #[action_output(bool)]
 struct ArmKick;
+
+#[derive(Component, Default)]
+struct AccumulatedInput {
+    roll: Vec2,
+    kick: Option<Vec2>,
+}

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -23,15 +23,12 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .init_resource::<DidFixedUpdateRunThisFrame>()
-        .add_systems(PreUpdate, reset_fixed_update_flag)
-        .add_systems(FixedPreUpdate, set_fixed_update_flag)
+        .init_resource::<FixedUpdateRan>()
+        .add_systems(PreUpdate, reset_fixed_update_ran)
+        .add_systems(FixedPreUpdate, set_fixed_update_ran)
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, (calculate_physics, update_gamepads))
-        .add_systems(
-            RunFixedMainLoop,
-            clear_input.run_if(did_fixed_update_run_this_frame),
-        )
+        .add_systems(RunFixedMainLoop, clear_input.run_if(fixed_update_ran))
         .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_roll)
         .add_observer(apply_kick)
@@ -283,16 +280,16 @@ struct AccumulatedInput {
 
 // Fixed timestep boilerplate
 #[derive(Resource, Deref, DerefMut, Default)]
-struct DidFixedUpdateRunThisFrame(bool);
+struct FixedUpdateRan(bool);
 
-fn reset_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
-    flag.0 = false;
+fn reset_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
+    **ran = false;
 }
 
-fn set_fixed_update_flag(mut flag: ResMut<DidFixedUpdateRunThisFrame>) {
-    flag.0 = true;
+fn set_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
+    **ran = true;
 }
 
-fn did_fixed_update_run_this_frame(flag: Res<DidFixedUpdateRunThisFrame>) -> bool {
-    flag.0
+fn fixed_update_ran(ran: Res<FixedUpdateRan>) -> bool {
+    **ran
 }


### PR DESCRIPTION
First bullet in #307 

Accumulates input and calculated physics in a fixed timestep like in [this example](https://bevy.org/examples/movement/physics-in-fixed-timestep/) and in [bevy_ahoy](https://github.com/janhohenheim/bevy_ahoy/blob/main/src/input.rs). It made no difference in feel for me, but from what I can tell this is supposed to make things smoother and prevent input from getting eaten in frame-drops. I tried to keep things simple.

I can also adjust the new `local_multiplayer` example to use a fixed timestep as well.