### PR TITLE
Simplified AccumulatedInput clearing in examples

### DIFF
--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -19,11 +19,10 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .add_systems(Startup, setup)
-        .init_resource::<FixedUpdateRan>()
-        .add_systems(PreUpdate, reset_fixed_update_ran)
-        .add_systems(FixedPreUpdate, set_fixed_update_ran)
-        .add_systems(FixedUpdate, calculate_physics)
-        .add_systems(RunFixedMainLoop, clear_input.run_if(fixed_update_ran))
+        .add_systems(
+            FixedUpdate,
+            ((calculate_physics), (apply_input, clear_input).chain()),
+        )
         .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_movement)
         .add_observer(apply_jump)
@@ -144,20 +143,4 @@ struct Jump;
 struct AccumulatedInput {
     movement: f32,
     jump: bool,
-}
-
-// Fixed timestep boilerplate
-#[derive(Resource, Deref, DerefMut, Default)]
-struct FixedUpdateRan(bool);
-
-fn reset_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
-    **ran = false;
-}
-
-fn set_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
-    **ran = true;
-}
-
-fn fixed_update_ran(ran: Res<FixedUpdateRan>) -> bool {
-    **ran
 }

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -21,7 +21,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(
             FixedUpdate,
-            ((calculate_physics), (apply_input, clear_input).chain()),
+            (apply_input, calculate_physics, clear_input).chain(),
         )
         .add_observer(apply_movement)
         .add_observer(apply_jump)

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -23,7 +23,6 @@ fn main() {
             FixedUpdate,
             ((calculate_physics), (apply_input, clear_input).chain()),
         )
-        .add_systems(FixedPostUpdate, apply_input)
         .add_observer(apply_movement)
         .add_observer(apply_jump)
         .run();

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -27,9 +27,8 @@ fn main() {
         .add_systems(
             FixedUpdate,
             (
-                (apply_input, clear_input).chain(),
+                (apply_input, calculate_physics, clear_input).chain(),
                 update_gamepads,
-                calculate_physics,
             ),
         )
         .add_observer(apply_roll)

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -23,13 +23,15 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .init_resource::<FixedUpdateRan>()
-        .add_systems(PreUpdate, reset_fixed_update_ran)
-        .add_systems(FixedPreUpdate, set_fixed_update_ran)
         .add_systems(Startup, setup)
-        .add_systems(FixedUpdate, (calculate_physics, update_gamepads))
-        .add_systems(RunFixedMainLoop, clear_input.run_if(fixed_update_ran))
-        .add_systems(FixedPostUpdate, apply_input)
+        .add_systems(
+            FixedUpdate,
+            (
+                (apply_input, clear_input).chain(),
+                update_gamepads,
+                calculate_physics,
+            ),
+        )
         .add_observer(apply_roll)
         .add_observer(apply_kick)
         .run();
@@ -276,20 +278,4 @@ struct ArmKick;
 struct AccumulatedInput {
     roll: Vec2,
     kick: Option<Vec2>,
-}
-
-// Fixed timestep boilerplate
-#[derive(Resource, Deref, DerefMut, Default)]
-struct FixedUpdateRan(bool);
-
-fn reset_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
-    **ran = false;
-}
-
-fn set_fixed_update_ran(mut ran: ResMut<FixedUpdateRan>) {
-    **ran = true;
-}
-
-fn fixed_update_ran(ran: Res<FixedUpdateRan>) -> bool {
-    **ran
 }


### PR DESCRIPTION
Turns out I was wrong on [this comment](https://github.com/simgine/bevy_enhanced_input/pull/323#issuecomment-4276564250) on my last PR.

It's true that both [this example](https://bevy.org/examples/movement/physics-in-fixed-timestep/) and bevy_ahoy use a similar `did_fixed_timestep_run_this_frame` mechanism, but both these cases are meant for greater extensibility and looser ordering. For the case of these examples, its fine just to chain the systems together.

As long as character controllers follow the pattern of:

accumulate input on input events -> apply input -> clear input

in that order, no input should be lost.