### PR TITLE
Corrected scheduling for character controller examples

### DIFF
--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -18,15 +18,30 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .add_systems(Startup, setup)
         .init_resource::<FixedUpdateRan>()
+        .add_systems(Startup, setup)
         .add_systems(PreUpdate, reset_fixed_update_ran)
-        .add_systems(FixedPreUpdate, set_fixed_update_ran)
-        .add_systems(FixedUpdate, calculate_physics)
-        .add_systems(RunFixedMainLoop, clear_input.run_if(fixed_update_ran))
-        .add_systems(FixedPostUpdate, apply_input)
-        .add_observer(apply_movement)
-        .add_observer(apply_jump)
+        .add_systems(
+            FixedPreUpdate,
+            (
+                set_fixed_update_ran,
+                // Apply input before advancing physics
+                apply_input,
+            ),
+        )
+        .add_systems(FixedUpdate, advance_physics)
+        .add_systems(
+            // Run outside the schedule loop that repeats FixedMain zero-to-many times
+            RunFixedMainLoop,
+            clear_input
+                // To prevent prematurely clearing input, only clear if
+                // FixedUpdate ran one-to-many times during this loop
+                .run_if(fixed_update_ran)
+                // Run *after* loop
+                .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
+        )
+        .add_observer(accumulate_movement)
+        .add_observer(accumulate_jump)
         .run();
 }
 
@@ -73,12 +88,12 @@ fn setup(
     ));
 }
 
-fn apply_movement(movement: On<Fire<Movement>>, mut inputs: Query<&mut AccumulatedInput>) {
+fn accumulate_movement(movement: On<Fire<Movement>>, mut inputs: Query<&mut AccumulatedInput>) {
     let mut accumulated_inputs = inputs.get_mut(movement.context).unwrap();
     accumulated_inputs.movement = movement.value;
 }
 
-fn apply_jump(jump: On<Fire<Jump>>, mut inputs: Query<&mut AccumulatedInput>) {
+fn accumulate_jump(jump: On<Fire<Jump>>, mut inputs: Query<&mut AccumulatedInput>) {
     let mut accumulated_inputs = inputs.get_mut(jump.context).unwrap();
     accumulated_inputs.jump = true;
 }
@@ -99,7 +114,7 @@ fn apply_input(players: Query<(&mut PlayerPhysics, &AccumulatedInput)>) {
     }
 }
 
-fn calculate_physics(
+fn advance_physics(
     fixed_time: Res<Time<Fixed>>,
     mut players: Query<(&mut Transform, &mut PlayerPhysics)>,
 ) {
@@ -146,7 +161,7 @@ struct AccumulatedInput {
     jump: bool,
 }
 
-// Fixed timestep boilerplate
+/// True if FixedPreUpdate was run this frame.
 #[derive(Resource, Deref, DerefMut, Default)]
 struct FixedUpdateRan(bool);
 

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -21,15 +21,10 @@ fn main() {
         .init_resource::<FixedUpdateRan>()
         .add_systems(Startup, setup)
         .add_systems(PreUpdate, reset_fixed_update_ran)
-        .add_systems(
-            FixedPreUpdate,
-            (
-                set_fixed_update_ran,
-                // Apply input before advancing physics
-                apply_input,
-            ),
-        )
-        .add_systems(FixedUpdate, advance_physics)
+        .add_systems(FixedPreUpdate, set_fixed_update_ran)
+        // Apply input before advancing physics
+        .add_systems(FixedUpdate, apply_input)
+        .add_systems(FixedPostUpdate, advance_physics)
         .add_systems(
             // Run outside the schedule loop that repeats FixedMain zero-to-many times
             RunFixedMainLoop,

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -28,8 +28,9 @@ fn main() {
         .init_resource::<FixedUpdateRan>()
         .add_systems(Startup, setup)
         .add_systems(PreUpdate, (reset_fixed_update_ran, update_gamepads))
-        .add_systems(FixedPreUpdate, (set_fixed_update_ran, apply_input))
-        .add_systems(FixedUpdate, advance_physics)
+        .add_systems(FixedPreUpdate, set_fixed_update_ran)
+        .add_systems(FixedUpdate, apply_input)
+        .add_systems(FixedPostUpdate, advance_physics)
         .add_systems(
             RunFixedMainLoop,
             clear_input

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -4,7 +4,7 @@
 //! This allows us to enable or disable players independently and reuse the same entity for gameplay,
 //! and assign unique input bindings to each player.
 //!
-//! Repeats the best practices used in character_controller example.
+//! Repeats the best practices used in `character_controller` example.
 
 use bevy::{
     input::gamepad::{GamepadConnection, GamepadConnectionEvent},

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -3,6 +3,8 @@
 //! The same context ([`Player`]) is used for both players, but each player has their own unique entity.
 //! This allows us to enable or disable players independently and reuse the same entity for gameplay,
 //! and assign unique input bindings to each player.
+//!
+//! Repeats the best practices used in character_controller example.
 
 use bevy::{
     input::gamepad::{GamepadConnection, GamepadConnectionEvent},
@@ -24,14 +26,18 @@ fn main() {
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
         .init_resource::<FixedUpdateRan>()
-        .add_systems(PreUpdate, reset_fixed_update_ran)
-        .add_systems(FixedPreUpdate, set_fixed_update_ran)
         .add_systems(Startup, setup)
-        .add_systems(FixedUpdate, (calculate_physics, update_gamepads))
-        .add_systems(RunFixedMainLoop, clear_input.run_if(fixed_update_ran))
-        .add_systems(FixedPostUpdate, apply_input)
-        .add_observer(apply_roll)
-        .add_observer(apply_kick)
+        .add_systems(PreUpdate, (reset_fixed_update_ran, update_gamepads))
+        .add_systems(FixedPreUpdate, (set_fixed_update_ran, apply_input))
+        .add_systems(FixedUpdate, advance_physics)
+        .add_systems(
+            RunFixedMainLoop,
+            clear_input
+                .run_if(fixed_update_ran)
+                .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
+        )
+        .add_observer(accumulate_roll)
+        .add_observer(accumulate_kick)
         .run();
 }
 
@@ -189,12 +195,12 @@ fn player_bundle(
     )
 }
 
-fn apply_roll(roll: On<Fire<Roll>>, mut input: Query<&mut AccumulatedInput>) {
+fn accumulate_roll(roll: On<Fire<Roll>>, mut input: Query<&mut AccumulatedInput>) {
     let mut input = input.get_mut(roll.context).unwrap();
     input.roll = roll.value;
 }
 
-fn apply_kick(kick: On<Fire<Kick>>, mut input: Query<&mut AccumulatedInput>) {
+fn accumulate_kick(kick: On<Fire<Kick>>, mut input: Query<&mut AccumulatedInput>) {
     let mut input = input.get_mut(kick.context).unwrap();
     input.kick = Some(kick.value);
 }
@@ -218,7 +224,7 @@ fn apply_input(players: Query<(&mut PlayerPhysics, &AccumulatedInput)>) {
     }
 }
 
-fn calculate_physics(time: Res<Time>, players: Query<(&mut Transform, &mut PlayerPhysics)>) {
+fn advance_physics(time: Res<Time>, players: Query<(&mut Transform, &mut PlayerPhysics)>) {
     for (mut transform, mut physics) in players {
         transform.translation += (physics.velocity * time.delta_secs()).extend(0.0);
 
@@ -278,7 +284,7 @@ struct AccumulatedInput {
     kick: Option<Vec2>,
 }
 
-// Fixed timestep boilerplate
+/// True if FixedPreUpdate was run this frame.
 #[derive(Resource, Deref, DerefMut, Default)]
 struct FixedUpdateRan(bool);
 


### PR DESCRIPTION
Based on feedback from #327

- Run `clear_input` after the entire `RunFixedMainLoop`
- put `update_gamepads` in `PreUpdate` as per [this comment](https://github.com/simgine/bevy_enhanced_input/pull/327#discussion_r3171415923)
- Changed `apply_{input type}` names to `accumulate_{input type}` for clarity
- added doc comment for `FixedUpdateRan`