### PR TITLE
Changed `DeltaScale` default to virtual time, added explicit constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Chord::ongoing` to control whether partial activation returns `TriggerState::Ongoing` or `TriggerState::None`.
+- `DeltaScale::real_time()` and `DeltaScale::virtual_time()` constructors.`
 
 ### Removed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve action evaluation logging.
+- **Breaking**: `DeltaScale::default()` now uses virtual time instead of real time.
 
 ## [0.24.4] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve action evaluation logging.
-- **Breaking**: `DeltaScale::default()` now uses virtual time instead of real time.
+- `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::real_time()`.
 
 ## [0.24.4] - 2026-04-18
 

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -65,9 +65,8 @@ fn setup(
             (
                 Action::<Movement>::new(),
                 DeadZone::default(),
+                // A smoothed input is directly applied to velocity.
                 SmoothNudge::default(),
-                // We don't apply `DeltaScale` here because the movement vector is
-                // multiplied by delta time during the physics calculation.
                 Scale::splat(450.0),
                 Bindings::spawn((
                     Bidirectional::new(KeyCode::KeyD, KeyCode::KeyA),

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -65,8 +65,10 @@ fn setup(
             (
                 Action::<Movement>::new(),
                 DeadZone::default(),
-                // A smoothed input is directly applied to velocity.
+                // Velocity is set to a smoothed input to simulate acceleration.
                 SmoothNudge::default(),
+                // We don't apply `DeltaScale` here because the movement vector is
+                // multiplied by delta time during the physics calculation.
                 Scale::splat(450.0),
                 Bindings::spawn((
                     Bidirectional::new(KeyCode::KeyD, KeyCode::KeyA),

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -25,6 +25,7 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
+        .add_input_context::<Shared>()
         .init_resource::<FixedUpdateRan>()
         .add_systems(Startup, setup)
         .add_systems(PreUpdate, (reset_fixed_update_ran, update_gamepads))
@@ -39,6 +40,7 @@ fn main() {
         )
         .add_observer(accumulate_roll)
         .add_observer(accumulate_kick)
+        .add_observer(toggle_pause)
         .run();
 }
 
@@ -98,6 +100,7 @@ fn setup(
         Transform::from_xyz(-80.0, 0.0, 0.0),
     ));
 
+    // Player 2
     let material2 = materials.add(Color::srgb(0.9, 0.1, 0.1));
     commands.spawn(player_bundle(
         Player::Second,
@@ -105,6 +108,32 @@ fn setup(
         ball_mesh,
         material2,
         Transform::from_xyz(80.0, 0.0, 0.0),
+    ));
+
+    // Shared player controls
+    commands.spawn((
+        Shared,
+        actions!(
+            Shared[(
+                Action::<Pause>::new(),
+                Press::new(1.0),
+                bindings![KeyCode::Escape, GamepadButton::Start]
+            )]
+        ),
+    ));
+
+    // Pause indicator
+    commands.spawn((
+        PauseIndicator,
+        Node {
+            width: percent(100),
+            height: percent(100),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            display: Display::None,
+            ..default()
+        },
+        children![Text::new("Paused")],
     ));
 }
 
@@ -167,7 +196,7 @@ fn player_bundle(
             context.spawn((
                 Action::<Roll>::new(),
                 DeadZone::default(),
-                DeltaScale::default(),
+                DeltaScale::virtual_time(),
                 Scale::splat(ACCELERATION),
                 Bindings::spawn(dir_bindings),
             ));
@@ -198,7 +227,7 @@ fn player_bundle(
 
 fn accumulate_roll(roll: On<Fire<Roll>>, mut input: Query<&mut AccumulatedInput>) {
     let mut input = input.get_mut(roll.context).unwrap();
-    input.roll = roll.value;
+    input.roll += roll.value;
 }
 
 fn accumulate_kick(kick: On<Fire<Kick>>, mut input: Query<&mut AccumulatedInput>) {
@@ -256,6 +285,21 @@ fn advance_physics(time: Res<Time>, players: Query<(&mut Transform, &mut PlayerP
     }
 }
 
+fn toggle_pause(
+    _: On<Fire<Pause>>,
+    mut time: ResMut<Time<Virtual>>,
+    mut indicator: Single<&mut Node, With<PauseIndicator>>,
+) {
+    let paused = time.is_paused();
+    if paused {
+        time.unpause();
+        indicator.display = Display::None;
+    } else {
+        time.pause();
+        indicator.display = Display::Flex;
+    }
+}
+
 #[derive(Component)]
 enum Player {
     First,
@@ -284,6 +328,16 @@ struct AccumulatedInput {
     roll: Vec2,
     kick: Option<Vec2>,
 }
+
+#[derive(Component)]
+struct Shared;
+
+#[derive(InputAction)]
+#[action_output(bool)]
+struct Pause;
+
+#[derive(Component)]
+struct PauseIndicator;
 
 /// True if FixedPreUpdate was run this frame.
 #[derive(Resource, Deref, DerefMut, Default)]

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -25,7 +25,7 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EnhancedInputPlugin))
         .add_input_context::<Player>()
-        .add_input_context::<Shared>()
+        .add_input_context::<SharedControls>()
         .init_resource::<FixedUpdateRan>()
         .add_systems(Startup, setup)
         .add_systems(PreUpdate, (reset_fixed_update_ran, update_gamepads))
@@ -110,11 +110,10 @@ fn setup(
         Transform::from_xyz(80.0, 0.0, 0.0),
     ));
 
-    // Shared player controls
     commands.spawn((
-        Shared,
+        SharedControls,
         actions!(
-            Shared[(
+            SharedControls[(
                 Action::<Pause>::new(),
                 Press::new(1.0),
                 bindings![KeyCode::Escape, GamepadButton::Start]
@@ -123,14 +122,14 @@ fn setup(
     ));
 
     commands.spawn((
-        PauseIndicator,
+        PauseText,
         Node {
             width: percent(100),
             height: percent(100),
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
             display: Display::None,
-            ..default()
+            ..Default::default()
         },
         children![Text::new("Paused")],
     ));
@@ -195,7 +194,7 @@ fn player_bundle(
             context.spawn((
                 Action::<Roll>::new(),
                 DeadZone::default(),
-                DeltaScale::virtual_time(),
+                DeltaScale::default(),
                 Scale::splat(ACCELERATION),
                 Bindings::spawn(dir_bindings),
             ));
@@ -285,12 +284,11 @@ fn advance_physics(time: Res<Time>, players: Query<(&mut Transform, &mut PlayerP
 }
 
 fn toggle_pause(
-    _: On<Fire<Pause>>,
+    _on: On<Fire<Pause>>,
     mut time: ResMut<Time<Virtual>>,
-    mut indicator: Single<&mut Node, With<PauseIndicator>>,
+    mut indicator: Single<&mut Node, With<PauseText>>,
 ) {
-    let paused = time.is_paused();
-    if paused {
+    if time.is_paused() {
         time.unpause();
         indicator.display = Display::None;
     } else {
@@ -329,14 +327,14 @@ struct AccumulatedInput {
 }
 
 #[derive(Component)]
-struct Shared;
+struct SharedControls;
 
 #[derive(InputAction)]
 #[action_output(bool)]
 struct Pause;
 
 #[derive(Component)]
-struct PauseIndicator;
+struct PauseText;
 
 /// True if FixedPreUpdate was run this frame.
 #[derive(Resource, Deref, DerefMut, Default)]

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -122,7 +122,6 @@ fn setup(
         ),
     ));
 
-    // Pause indicator
     commands.spawn((
         PauseIndicator,
         Node {

--- a/src/context.rs
+++ b/src/context.rs
@@ -954,6 +954,7 @@ pub(crate) fn init_world<'w, 's>() -> (World, SystemState<(ContextTime<'w>, Acti
     let mut world = World::new();
     world.init_resource::<Time>();
     world.init_resource::<Time<Real>>();
+    world.init_resource::<Time<Virtual>>();
 
     let state = SystemState::<(ContextTime, ActionsQuery)>::new(&mut world);
 

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -10,7 +10,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 #[derive(SystemParam, Deref)]
 pub struct ContextTime<'w> {
     #[deref]
-    pub virt: Res<'w, Time>,
+    pub virt: Res<'w, Time<Virtual>>,
     pub real: Res<'w, Time<Real>>,
 }
 

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -10,7 +10,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 #[derive(SystemParam, Deref)]
 pub struct ContextTime<'w> {
     #[deref]
-    pub virt: Res<'w, Time<Virtual>>,
+    pub virt: Res<'w, Time>,
     pub real: Res<'w, Time<Real>>,
 }
 

--- a/src/modifier/delta_scale.rs
+++ b/src/modifier/delta_scale.rs
@@ -5,15 +5,36 @@ use crate::prelude::*;
 /// Multiplies the input value by delta time for this frame.
 ///
 /// [`ActionValue::Bool`] will be transformed into [`ActionValue::Axis1D`].
-#[derive(Component, Default, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy)]
 #[cfg_attr(
     feature = "reflect",
     derive(Reflect),
     reflect(Clone, Component, Debug, Default)
 )]
 pub struct DeltaScale {
-    /// The type of time used to advance the timer.
+    /// The type of time used to scale the input by.
     pub time_kind: TimeKind,
+}
+
+impl DeltaScale {
+    pub fn real_time() -> Self {
+        Self {
+            time_kind: TimeKind::Real,
+        }
+    }
+
+    pub fn virtual_time() -> Self {
+        Self {
+            time_kind: TimeKind::Virtual,
+        }
+    }
+}
+
+impl Default for DeltaScale {
+    /// Uses `TimeKind::Virtual` by default.
+    fn default() -> Self {
+        Self::virtual_time()
+    }
 }
 
 impl InputModifier for DeltaScale {
@@ -51,7 +72,7 @@ mod tests {
     use crate::context;
 
     #[test]
-    fn scaling() {
+    fn real_scaling() {
         let (mut world, mut state) = context::init_world();
         world
             .resource_mut::<Time<Real>>()
@@ -59,23 +80,53 @@ mod tests {
         let (time, actions) = state.get(&world);
 
         assert_eq!(
-            DeltaScale::default().transform(&actions, &time, true.into()),
+            DeltaScale::real_time().transform(&actions, &time, true.into()),
             0.5.into()
         );
         assert_eq!(
-            DeltaScale::default().transform(&actions, &time, false.into()),
+            DeltaScale::real_time().transform(&actions, &time, false.into()),
             0.0.into()
         );
         assert_eq!(
-            DeltaScale::default().transform(&actions, &time, 0.5.into()),
+            DeltaScale::real_time().transform(&actions, &time, 0.5.into()),
             0.25.into()
         );
         assert_eq!(
-            DeltaScale::default().transform(&actions, &time, Vec2::ONE.into()),
+            DeltaScale::real_time().transform(&actions, &time, Vec2::ONE.into()),
             (0.5, 0.5).into()
         );
         assert_eq!(
-            DeltaScale::default().transform(&actions, &time, Vec3::ONE.into()),
+            DeltaScale::real_time().transform(&actions, &time, Vec3::ONE.into()),
+            (0.5, 0.5, 0.5).into()
+        );
+    }
+
+    #[test]
+    fn virtual_scaling() {
+        let (mut world, mut state) = context::init_world();
+        world
+            .resource_mut::<Time<Virtual>>()
+            .advance_by(Duration::from_millis(500));
+        let (time, actions) = state.get(&world);
+
+        assert_eq!(
+            DeltaScale::virtual_time().transform(&actions, &time, true.into()),
+            0.5.into()
+        );
+        assert_eq!(
+            DeltaScale::virtual_time().transform(&actions, &time, false.into()),
+            0.0.into()
+        );
+        assert_eq!(
+            DeltaScale::virtual_time().transform(&actions, &time, 0.5.into()),
+            0.25.into()
+        );
+        assert_eq!(
+            DeltaScale::virtual_time().transform(&actions, &time, Vec2::ONE.into()),
+            (0.5, 0.5).into()
+        );
+        assert_eq!(
+            DeltaScale::virtual_time().transform(&actions, &time, Vec3::ONE.into()),
             (0.5, 0.5, 0.5).into()
         );
     }

--- a/src/modifier/delta_scale.rs
+++ b/src/modifier/delta_scale.rs
@@ -19,10 +19,12 @@ pub struct DeltaScale {
 }
 
 impl DeltaScale {
+    /// Instance with [`TimeKind::Real`].
     pub const REAL: Self = Self {
         time_kind: TimeKind::Real,
     };
 
+    /// Instance with [`TimeKind::Virtual`].
     pub const VIRTUAL: Self = Self {
         time_kind: TimeKind::Virtual,
     };

--- a/src/modifier/delta_scale.rs
+++ b/src/modifier/delta_scale.rs
@@ -13,27 +13,24 @@ use crate::prelude::*;
 )]
 pub struct DeltaScale {
     /// The type of time used to scale the input by.
+    ///
+    /// `TimeKind::Virtual` by default for `DeltaScale` only.
     pub time_kind: TimeKind,
 }
 
 impl DeltaScale {
-    pub fn real_time() -> Self {
-        Self {
-            time_kind: TimeKind::Real,
-        }
-    }
+    pub const REAL: Self = Self {
+        time_kind: TimeKind::Real,
+    };
 
-    pub fn virtual_time() -> Self {
-        Self {
-            time_kind: TimeKind::Virtual,
-        }
-    }
+    pub const VIRTUAL: Self = Self {
+        time_kind: TimeKind::Virtual,
+    };
 }
 
 impl Default for DeltaScale {
-    /// Uses `TimeKind::Virtual` by default.
     fn default() -> Self {
-        Self::virtual_time()
+        Self::VIRTUAL
     }
 }
 
@@ -72,61 +69,31 @@ mod tests {
     use crate::context;
 
     #[test]
-    fn real_scaling() {
+    fn scaling() {
         let (mut world, mut state) = context::init_world();
         world
-            .resource_mut::<Time<Real>>()
+            .resource_mut::<Time>()
             .advance_by(Duration::from_millis(500));
         let (time, actions) = state.get(&world);
 
         assert_eq!(
-            DeltaScale::real_time().transform(&actions, &time, true.into()),
+            DeltaScale::default().transform(&actions, &time, true.into()),
             0.5.into()
         );
         assert_eq!(
-            DeltaScale::real_time().transform(&actions, &time, false.into()),
+            DeltaScale::default().transform(&actions, &time, false.into()),
             0.0.into()
         );
         assert_eq!(
-            DeltaScale::real_time().transform(&actions, &time, 0.5.into()),
+            DeltaScale::default().transform(&actions, &time, 0.5.into()),
             0.25.into()
         );
         assert_eq!(
-            DeltaScale::real_time().transform(&actions, &time, Vec2::ONE.into()),
+            DeltaScale::default().transform(&actions, &time, Vec2::ONE.into()),
             (0.5, 0.5).into()
         );
         assert_eq!(
-            DeltaScale::real_time().transform(&actions, &time, Vec3::ONE.into()),
-            (0.5, 0.5, 0.5).into()
-        );
-    }
-
-    #[test]
-    fn virtual_scaling() {
-        let (mut world, mut state) = context::init_world();
-        world
-            .resource_mut::<Time<Virtual>>()
-            .advance_by(Duration::from_millis(500));
-        let (time, actions) = state.get(&world);
-
-        assert_eq!(
-            DeltaScale::virtual_time().transform(&actions, &time, true.into()),
-            0.5.into()
-        );
-        assert_eq!(
-            DeltaScale::virtual_time().transform(&actions, &time, false.into()),
-            0.0.into()
-        );
-        assert_eq!(
-            DeltaScale::virtual_time().transform(&actions, &time, 0.5.into()),
-            0.25.into()
-        );
-        assert_eq!(
-            DeltaScale::virtual_time().transform(&actions, &time, Vec2::ONE.into()),
-            (0.5, 0.5).into()
-        );
-        assert_eq!(
-            DeltaScale::virtual_time().transform(&actions, &time, Vec3::ONE.into()),
+            DeltaScale::default().transform(&actions, &time, Vec3::ONE.into()),
             (0.5, 0.5, 0.5).into()
         );
     }

--- a/src/modifier/delta_scale.rs
+++ b/src/modifier/delta_scale.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 pub struct DeltaScale {
     /// The type of time used to scale the input by.
     ///
-    /// `TimeKind::Virtual` by default for `DeltaScale` only.
+    /// By default set to [`TimeKind::Virtual`], unlike other modifiers.
     pub time_kind: TimeKind,
 }
 


### PR DESCRIPTION
CLOSE #331 

Name is self explanatory. I've confirmed that the pause bug in the issue was in fact present when a pause screen was introduced (and `=` was changed to `+=` to properly accumulate the input). See for yourself by setting the `DeltaScale` in `local_multiplayer.rs` to `real_time()`, then hold a direction while paused and see the ball slingshot when unpausing.

A few minor improvements for testing, though it is still quite difficult to simulate the effects of pausing and scaling virtual time in unit tests.