### PR TITLE
Rename `TimeKind::Virtual` to `TimeKind::Auto` (and `virt` -> `auto` for `ContextTime`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve action evaluation logging.
 - `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::real_time()`.
-- Deprecated `TimeKind::Virtual` in favor of the name `TimeKind::Auto`, which is more accurate to the functionality.
-- Deprecated `virt` field of `ContextTime` and replaced with `auto` field.
+- Rename `TimeKind::Virtual` to `TimeKind::Auto` and `ContextTime::virt` to `ContextTime::auto`. The old names remain available as deprecated aliases.
 
 ## [0.24.4] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve action evaluation logging.
 - `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::real_time()`.
+- Deprecated `TimeKind::Virtual` in favor of the name `TimeKind::Auto`, which is more accurate to the functionality.
+- Deprecated `virt` field of `ContextTime` and replaced with `auto` field.
 
 ## [0.24.4] - 2026-04-18
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -57,6 +57,7 @@ triggering the corresponding events. Depending on your use case, using [`Context
 
 pub mod input_reader;
 pub mod instance;
+#[allow(deprecated)]
 pub mod time;
 mod trigger_tracker;
 

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -50,12 +50,7 @@ pub enum TimeKind {
     ///
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
     Auto,
-    /// Corresponds to [`Time`], which contains [`Time<Virtual>`], except in the fixed schedule,
-    /// where it's [`Time<Fixed>`].
-    ///
-    /// Virtual game time, affected by [`Time::pause`] and [`Time::relative_speed`].
-    ///
-    /// Useful for time-based actions that needs to be paused or speedup together with the game.
+    /// A deprecated alias for [`Self::Auto``].
     #[deprecated(
         since = "0.25.0",
         note = "Renamed into `Auto`"

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -11,7 +11,6 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 pub struct ContextTime<'w> {
     #[deref]
     pub auto: Res<'w, Time>,
-    #[allow(deprecated)]
     #[deprecated(
         since = "0.25.0",
         note = "Naming wasn't accurate to functionality, use auto instead."
@@ -25,7 +24,6 @@ impl ContextTime<'_> {
     #[must_use]
     pub fn delta_kind(&self, kind: TimeKind) -> Duration {
         match kind {
-            #[allow(deprecated)]
             TimeKind::Auto | TimeKind::Virtual => self.auto.delta(),
             TimeKind::Real => self.real.delta(),
         }
@@ -58,7 +56,6 @@ pub enum TimeKind {
     /// Virtual game time, affected by [`Time::pause`] and [`Time::relative_speed`].
     ///
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
-    #[allow(deprecated)]
     #[deprecated(
         since = "0.25.0",
         note = "Naming wasn't accurate to functionality, use Auto instead."

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -11,10 +11,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 pub struct ContextTime<'w> {
     #[deref]
     pub auto: Res<'w, Time>,
-    #[deprecated(
-        since = "0.25.0",
-        note = "Renamed into `auto`"
-    )]
+    #[deprecated(since = "0.25.0", note = "Renamed into `auto`")]
     pub virt: Res<'w, Time>,
     pub real: Res<'w, Time<Real>>,
 }
@@ -51,9 +48,6 @@ pub enum TimeKind {
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
     Auto,
     /// A deprecated alias for [`Self::Auto``].
-    #[deprecated(
-        since = "0.25.0",
-        note = "Renamed into `Auto`"
-    )]
+    #[deprecated(since = "0.25.0", note = "Renamed into `Auto`")]
     Virtual,
 }

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -47,7 +47,7 @@ pub enum TimeKind {
     ///
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
     Auto,
-    /// A deprecated alias for [`Self::Auto``].
+    /// A deprecated alias for [`Self::Auto`].
     #[deprecated(since = "0.25.0", note = "Renamed into `Auto`")]
     Virtual,
 }

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -4,7 +4,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 
 /// Time resources used for input conditions and modifier evaluation.
 ///
-/// Dereferences to [`Self::virt`], which is the default time resource
+/// Dereferences to [`Self::auto`], which is the default time resource
 /// based on the current schedule. But you can optionally use [`Self::real`]
 /// if you want the time to be unaffected by time dilation.
 #[derive(SystemParam, Deref)]

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -58,7 +58,7 @@ pub enum TimeKind {
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
     #[deprecated(
         since = "0.25.0",
-        note = "Naming wasn't accurate to functionality, use Auto instead."
+        note = "Renamed into `Auto`"
     )]
     Virtual,
 }

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -12,7 +12,10 @@ pub struct ContextTime<'w> {
     #[deref]
     pub auto: Res<'w, Time>,
     #[allow(deprecated)]
-    #[deprecated = "Naming wasn't accurate to functionality, use auto instead."]
+    #[deprecated(
+        since = "0.25.0",
+        note = "Naming wasn't accurate to functionality, use auto instead."
+    )]
     pub virt: Res<'w, Time>,
     pub real: Res<'w, Time<Real>>,
 }
@@ -56,6 +59,9 @@ pub enum TimeKind {
     ///
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
     #[allow(deprecated)]
-    #[deprecated = "Naming wasn't accurate to functionality, use Auto instead."]
+    #[deprecated(
+        since = "0.25.0",
+        note = "Naming wasn't accurate to functionality, use Auto instead."
+    )]
     Virtual,
 }

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -10,6 +10,9 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 #[derive(SystemParam, Deref)]
 pub struct ContextTime<'w> {
     #[deref]
+    pub auto: Res<'w, Time>,
+    #[allow(deprecated)]
+    #[deprecated = "Naming wasn't accurate to functionality, use auto instead."]
     pub virt: Res<'w, Time>,
     pub real: Res<'w, Time<Real>>,
 }
@@ -19,7 +22,8 @@ impl ContextTime<'_> {
     #[must_use]
     pub fn delta_kind(&self, kind: TimeKind) -> Duration {
         match kind {
-            TimeKind::Virtual => self.virt.delta(),
+            #[allow(deprecated)]
+            TimeKind::Auto | TimeKind::Virtual => self.auto.delta(),
             TimeKind::Real => self.real.delta(),
         }
     }
@@ -44,5 +48,14 @@ pub enum TimeKind {
     /// Virtual game time, affected by [`Time::pause`] and [`Time::relative_speed`].
     ///
     /// Useful for time-based actions that needs to be paused or speedup together with the game.
+    Auto,
+    /// Corresponds to [`Time`], which contains [`Time<Virtual>`], except in the fixed schedule,
+    /// where it's [`Time<Fixed>`].
+    ///
+    /// Virtual game time, affected by [`Time::pause`] and [`Time::relative_speed`].
+    ///
+    /// Useful for time-based actions that needs to be paused or speedup together with the game.
+    #[allow(deprecated)]
+    #[deprecated = "Naming wasn't accurate to functionality, use Auto instead."]
     Virtual,
 }

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -13,7 +13,7 @@ pub struct ContextTime<'w> {
     pub auto: Res<'w, Time>,
     #[deprecated(
         since = "0.25.0",
-        note = "Naming wasn't accurate to functionality, use auto instead."
+        note = "Renamed into `auto`"
     )]
     pub virt: Res<'w, Time>,
     pub real: Res<'w, Time<Real>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,8 +353,6 @@ pub mod preset;
 pub mod state;
 
 pub mod prelude {
-    #[allow(deprecated)]
-    pub use super::action::ActionState;
     #[cfg(feature = "state")]
     pub use super::state::{ActiveInStates, StateContextAppExt};
     pub use super::{
@@ -384,7 +382,6 @@ pub mod prelude {
         context::{
             ActionsQuery, ContextActivity, ContextPriority, GamepadDevice, InputContextAppExt,
             input_reader::ActionSources,
-            time::{ContextTime, TimeKind},
         },
         modifier::{
             InputModifier, accumulate_by::*, clamp::*, dead_zone::*, delta_scale::*,
@@ -392,6 +389,11 @@ pub mod prelude {
             smooth_nudge::*, swizzle_axis::*,
         },
         preset::{WithBundle, axial::*, bidirectional::*, cardinal::*, ordinal::*, spatial::*},
+    };
+    #[allow(deprecated)]
+    pub use super::{
+        action::ActionState,
+        context::time::{ContextTime, TimeKind},
     };
     pub use bevy_enhanced_input_macros::InputAction;
 }

--- a/src/modifier/delta_scale.rs
+++ b/src/modifier/delta_scale.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 pub struct DeltaScale {
     /// The type of time used to scale the input by.
     ///
-    /// By default set to [`TimeKind::Virtual`], unlike other modifiers.
+    /// By default set to [`TimeKind::Auto`], unlike other modifiers.
     pub time_kind: TimeKind,
 }
 

--- a/src/modifier/delta_scale.rs
+++ b/src/modifier/delta_scale.rs
@@ -24,15 +24,15 @@ impl DeltaScale {
         time_kind: TimeKind::Real,
     };
 
-    /// Instance with [`TimeKind::Virtual`].
-    pub const VIRTUAL: Self = Self {
-        time_kind: TimeKind::Virtual,
+    /// Instance with [`TimeKind::Auto`].
+    pub const AUTO: Self = Self {
+        time_kind: TimeKind::Auto,
     };
 }
 
 impl Default for DeltaScale {
     fn default() -> Self {
-        Self::VIRTUAL
+        Self::AUTO
     }
 }
 


### PR DESCRIPTION
#333 

Was unsure of a couple of things:
- I had to `#[allow(deprecated)]` in some funky places to suppress warnings.
- I think I got the semantic versioning correct in all the new `#[deprecated]` traits, but let me know otherwise.
- I just copied the doc comment between `TimeKind::Virtual` and `TimeKind::Real`. I'm not certain this is best practice.