### PR TITLE
Fixed misleading notes in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Binding::Custom` and the `CustomInputs` resource for feeding external input values into bindings by name.
 - `Chord::ongoing` to control whether partial activation returns `TriggerState::Ongoing` or `TriggerState::None`.
-- `DeltaScale::real_time()` and `DeltaScale::virtual_time()` constructors.`
+- `DeltaScale::REAL` and `DeltaScale::AUTO` constants.
 
 ### Changed
 
 - Improve action evaluation logging.
-- `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::real_time()`.
+- `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::REAL`.
 - Rename `TimeKind::Virtual` to `TimeKind::Auto` and `ContextTime::virt` to `ContextTime::auto`. The old names remain available as deprecated aliases.
 
 ### Removed


### PR DESCRIPTION
We decided on the constants approach instead of a constructor approach mid-PR. My bad for not updating the changelog alongside that decision.