### PR TITLE
Scale `MouseScrollUnit::Pixels` to `Line` to handle trackpad scaling on e.g. macOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve action evaluation logging.
 - `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::REAL`.
 - Rename `TimeKind::Virtual` to `TimeKind::Auto` and `ContextTime::virt` to `ContextTime::auto`. The old names remain available as deprecated aliases.
+- Adjusted the scaling of input values for `Binding::mouse_wheel()` when input comes from trackpads, so they are scaled the same as mouse wheels. (In other words, `MouseWheel` events measured in `MouseWheelUnit::Pixels` now result in a similar feel as those from `MouseWheelUnit::Lines`, by dividing by `MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR`.)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adjust the scaling of input values for `Binding::mouse_wheel()` when input comes from trackpads, so they are scaled the same as mouse wheels. In other words, `MouseWheel` events measured in `MouseWheelUnit::Pixels` now result in a similar feel as those from `MouseWheelUnit::Lines`, by dividing by `MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR`.
+
 ## [0.25.0] - 2026-05-16
 
 ### Added
@@ -20,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve action evaluation logging.
 - `DeltaScale::default()` now uses virtual time instead of real time. This is most likely what you want, since it's equivalent to getting the delta from [the default `Time` resource](https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html). If you want the original behavior, use `DeltaScale::REAL`.
 - Rename `TimeKind::Virtual` to `TimeKind::Auto` and `ContextTime::virt` to `ContextTime::auto`. The old names remain available as deprecated aliases.
-- Adjusted the scaling of input values for `Binding::mouse_wheel()` when input comes from trackpads, so they are scaled the same as mouse wheels. (In other words, `MouseWheel` events measured in `MouseWheelUnit::Pixels` now result in a similar feel as those from `MouseWheelUnit::Lines`, by dividing by `MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR`.)
 
 ### Removed
 

--- a/src/context/input_reader.rs
+++ b/src/context/input_reader.rs
@@ -5,7 +5,7 @@ use core::{any::TypeId, hash::Hash, iter, mem};
 
 use bevy::{
     ecs::{schedule::ScheduleLabel, system::SystemParam},
-    input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll},
+    input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll, MouseScrollUnit},
     platform::collections::HashSet,
     prelude::*,
     utils::TypeIdMap,
@@ -119,7 +119,13 @@ impl InputReader<'_, '_> {
 
                 self.mouse_scroll
                     .as_ref()
-                    .map(|s| s.delta)
+                    .map(|s|
+                        // Get a scroll amount proportional to the kind of input that generated it.
+                        match s.unit {
+                            MouseScrollUnit::Line => s.delta,
+                            MouseScrollUnit::Pixel => s.delta / MouseScrollUnit::SCROLL_UNIT_CONVERSION_FACTOR,
+                        }
+                    )
                     .unwrap_or_default()
                     .into()
             }


### PR DESCRIPTION
This makes mouse scroll wheel and trackpad scrolling have a similar "feel", since otherwise the trackpad moves about ~100 faster than it should.

See https://discord.com/channels/691052431525675048/1297361733886677036/1508839415970267342 for detail.